### PR TITLE
feat(campspot-bot): auto-cart bot for Upper Pines campground

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,8 @@ permit-bot/.last-page-snapshot.html
 permit-bot/.dom-fingerprint.json
 permit-bot/logs/
 permit-bot/reports/
+
+campspot-bot/.screenshots/
+campspot-bot/.traces/
+campspot-bot/logs/
+campspot-bot/.chromium-probe/

--- a/campspot-bot/CampspotCartBot.mjs
+++ b/campspot-bot/CampspotCartBot.mjs
@@ -1,0 +1,300 @@
+// Playwright cart automation for rec.gov campground reservations.
+//
+// Flow (validated 2026-06-22 against Upper Pines via probe scripts):
+//   1. Open  /camping/campgrounds/{cgId}?startdate=X&enddate=Y   (Y = checkout)
+//   2. Handle login modal if present (re-uses permit-bot helper).
+//   3. Page renders a per-site grid showing ~10 days at a time.
+//      Each cell is <button class="rec-availability-date">
+//      with aria-label of the form
+//        "<MonthAbbrev> <Day>, <Year> - Site <SiteNo> is available"   (avail)
+//        "<MonthAbbrev> <Day>, <Year> - Site <SiteNo> is Reserved"    (taken)
+//      Navigate forward via button[aria-label="Go Forward 5 Days"] until the
+//      target cell is visible.
+//   4. Click the cell. The page interprets startdate/enddate from the URL and
+//      treats the cell click as "I'll take site <N> for this trip range." An
+//      "Add to Cart" button appears immediately (verified single-click).
+//   5. Click "Add to Cart". May prompt login if session expired; handle it.
+//   6. Verify state at /cart. The cart page shows the site name + date range
+//      with a 15-min countdown when the hold is real.
+//
+// `tryGrabCampsite` is the one-shot entry: it does steps 1-6 in dry-run or
+// for-real mode and returns a result object the CLI logs / Discords.
+import { chromium } from 'playwright'
+import path from 'node:path'
+import { mkdir } from 'node:fs/promises'
+import { getAccount, handleLoginModalIfPresent } from '../permit-bot/CartBot.mjs'
+import { resolveForChromium } from '../permit-bot/dnsBypass.mjs'
+
+const VIEWPORT = { width: 1400, height: 1100 }
+const HOSTS_TO_PIN = ['www.recreation.gov', 'recreation.gov']
+const MONTH_NAMES = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
+
+function arialLabelForCell({ siteNo, date, status }) {
+    const [y, m, d] = date.split('-').map(Number)
+    return `${MONTH_NAMES[m - 1]} ${d}, ${y} - Site ${siteNo} is ${status}`
+}
+
+async function launchCampspotContext({ headless = false, accountIndex = 1 } = {}) {
+    const acct = getAccount(accountIndex)
+    // Reuses the permit-bot account directory so a single rec.gov login covers
+    // both bots. permit-bot.mjs `login --account=N` is the canonical way to
+    // establish a session.
+    await mkdir(acct.profileDir, { recursive: true })
+
+    const rules = []
+    for (const host of HOSTS_TO_PIN) {
+        try {
+            const ip = await resolveForChromium(host)
+            rules.push(`MAP ${host} ${ip}`)
+        } catch { /* best-effort */ }
+    }
+    const args = [
+        '--disable-blink-features=AutomationControlled',
+        '--disable-features=DnsOverHttps,AsyncDns',
+    ]
+    if (rules.length > 0) args.push(`--host-resolver-rules=${rules.join(',')}`)
+    return chromium.launchPersistentContext(acct.profileDir, {
+        headless,
+        viewport: VIEWPORT,
+        args,
+    })
+}
+
+// Advance the calendar grid by clicking "Go Forward 5 Days" until the target
+// date is one of the rendered columns. Returns true on success. Caps at
+// `maxAdvances` to bound the walk (default 40 → 200 days from today).
+export async function advanceCalendarTo(page, targetDate, { log = console, maxAdvances = 40 } = {}) {
+    const fwd = page.locator('button[aria-label="Go Forward 5 Days"]').first()
+    if (await fwd.count() === 0) {
+        log.warn?.('No "Go Forward 5 Days" button — calendar widget missing or page not loaded')
+        return false
+    }
+    const isVisible = async () => {
+        // The grid renders header columns with aria-labels matching
+        // "<MonthAbbrev> <Day>, <Year>" prefix on every cell for that day.
+        const [y, m, d] = targetDate.split('-').map(Number)
+        const prefix = `${MONTH_NAMES[m - 1]} ${d}, ${y}`
+        const cell = page.locator(`[aria-label^="${prefix}"]`).first()
+        return (await cell.count()) > 0
+    }
+    if (await isVisible()) return true
+    for (let i = 0; i < maxAdvances; i++) {
+        await fwd.click({ timeout: 2500 }).catch(() => {})
+        await page.waitForTimeout(450)
+        if (await isVisible()) return true
+    }
+    log.warn?.(`advanceCalendarTo: target ${targetDate} not visible after ${maxAdvances} advances`)
+    return false
+}
+
+// Find the Available cell for (siteNo, date). Returns the Playwright Locator
+// or null. Tolerates rec.gov's mixed-case ("is available" lowercase verified
+// 2026-06-22, but defensive). Site number is matched exactly — rec.gov shows
+// "Site 046" with leading zeros, so caller must pass the padded form.
+export async function findAvailableCell(page, { siteNo, date }) {
+    const label = arialLabelForCell({ siteNo, date, status: 'available' })
+    const cell = page.locator(`[aria-label="${label}" i]`).first()
+    return (await cell.count()) > 0 ? cell : null
+}
+
+// One-shot: navigate to /cart in a fresh tab and read the body text to verify
+// the hold. Returns { state: 'held' | 'empty' | 'has_items_but_not_target' |
+// 'unknown', cartText, cartShot }.
+//
+// rec.gov cart format (verified 2026-06-22 by a real auto-grab):
+//   "192, Upper Pines RV NONELECTRIC"
+//   "Check-In Date: Sun Sep 13, 2026"
+// So we match site number + a human-formatted date ("Sep 13") rather than the
+// ISO start date. Two-signal AND-match avoids false-positives from a stale
+// prior hold for a different (site, date).
+async function verifyCartHold(ctx, { siteNo, startDate, endDate, screenshotPath }) {
+    const cartPage = await ctx.newPage()
+    let cartShot = null
+    let state = 'unknown'
+    let cartText = ''
+    try {
+        await cartPage.goto('https://www.recreation.gov/cart', { waitUntil: 'domcontentloaded', timeout: 20000 })
+        await cartPage.waitForTimeout(2500)
+        cartShot = screenshotPath('cart')
+        await cartPage.screenshot({ path: cartShot, fullPage: true })
+        cartText = await cartPage.evaluate(() => document.body.innerText)
+        const lower = cartText.toLowerCase()
+        const [sy, sm, sd] = startDate.split('-').map(Number)
+        const humanDate = `${MONTH_NAMES[sm - 1]} ${sd}, ${sy}`.toLowerCase()
+        const sitePattern = new RegExp(`(?:^|\\W)${siteNo.replace(/^0+/, '0*')}(?:,|\\s)`, 'i')
+        if (/your cart is empty/i.test(cartText)) state = 'empty'
+        else if (sitePattern.test(cartText) && lower.includes(humanDate)) state = 'held'
+        else if (/cart/i.test(cartText)) state = 'has_items_but_not_target'
+    } finally {
+        await cartPage.close().catch(() => {})
+    }
+    return { state, cartText, cartShot }
+}
+
+// Add a single (campsiteId, siteNo, startDate, endDate) stay to the cart.
+// `dryRun` stops just before clicking "Add to Cart" — useful for selector
+// validation against arbitrary dates without polluting the user's cart.
+// `endDate` is the checkout date (one day after the last night).
+export async function tryGrabCampsite({
+    campgroundId,
+    campsiteId,         // numeric — used in screenshots / logs
+    siteNo,             // e.g. "068" — what the rec.gov aria-label says
+    startDate,          // YYYY-MM-DD (first night)
+    endDate,            // YYYY-MM-DD (checkout)
+    dryRun = true,
+    accountIndex = 1,
+    log = console,
+} = {}) {
+    const acct = getAccount(accountIndex)
+    const url = `https://www.recreation.gov/camping/campgrounds/${campgroundId}?startdate=${startDate}&enddate=${endDate}`
+    log.info(`tryGrabCampsite: cg=${campgroundId} site=${siteNo} (${startDate} → ${endDate}) dryRun=${dryRun} acct=${accountIndex}(${acct.email})`)
+
+    const shotsDir = path.resolve('./campspot-bot/.screenshots')
+    await mkdir(shotsDir, { recursive: true })
+    const screenshotPath = (label) =>
+        path.resolve(`${shotsDir}/${Date.now()}-cg${campgroundId}-site${siteNo}-${label}.png`)
+
+    const ctx = await launchCampspotContext({ headless: false, accountIndex })
+    const page = await ctx.newPage()
+    page.setDefaultTimeout(15000)
+
+    try {
+        await page.goto(url, { waitUntil: 'domcontentloaded' })
+        await page.waitForTimeout(3500)
+        await handleLoginModalIfPresent(page, { log, accountIndex })
+        await page.screenshot({ path: screenshotPath('01-loaded'), fullPage: true })
+
+        // Step 1: advance calendar to startDate (the grid shows ~10 days, so a
+        // Sept date may need 12+ next-clicks from today).
+        log.info('Step 1: advance calendar grid to target date')
+        const advanced = await advanceCalendarTo(page, startDate, { log, maxAdvances: 60 })
+        if (!advanced) {
+            await page.screenshot({ path: screenshotPath('err-no-date'), fullPage: true })
+            return { ok: false, reason: 'date_not_in_grid', ctx, page }
+        }
+
+        // Step 2: find the available cell for site + start date.
+        log.info(`Step 2: find available cell for site ${siteNo}`)
+        const cell = await findAvailableCell(page, { siteNo, date: startDate })
+        if (!cell) {
+            log.warn(`No Available cell for site ${siteNo} on ${startDate} — slot likely just got taken`)
+            await page.screenshot({ path: screenshotPath('err-no-avail'), fullPage: true })
+            return { ok: false, reason: 'cell_not_available', ctx, page }
+        }
+        await cell.scrollIntoViewIfNeeded().catch(() => {})
+
+        if (dryRun) {
+            log.info('[dry-run] Cell located, NOT clicking.')
+            await page.screenshot({ path: screenshotPath('dryrun-located'), fullPage: true })
+            return { ok: true, dryRun: true, ctx, page }
+        }
+
+        // Step 3: click the start cell to select the site for this trip range.
+        log.info('Step 3: click Available cell')
+        await cell.click()
+        await page.waitForTimeout(1500)
+        await page.screenshot({ path: screenshotPath('02-after-cell-click'), fullPage: true })
+
+        // Step 4: click "Add to Cart". The button appears after the cell click
+        // and may briefly be disabled while the page settles.
+        log.info('Step 4: click Add to Cart')
+        const addBtn = page.locator(
+            'button:has-text("Add to Cart"), #add-cart-campsite, button[aria-label*="Add to Cart" i]'
+        ).first()
+        await addBtn.waitFor({ state: 'visible', timeout: 10000 })
+        await page.waitForFunction(
+            () => {
+                const btns = [...document.querySelectorAll('button')]
+                const b = btns.find(x => /add to cart/i.test(x.textContent?.trim() || ''))
+                return b && !b.disabled && !/true/i.test(b.getAttribute('aria-disabled') || '')
+            },
+            null,
+            { timeout: 8000, polling: 200 },
+        ).catch(() => log.warn('Add to Cart did not become enabled; clicking anyway'))
+        await addBtn.click()
+        log.info('Clicked Add to Cart')
+        await page.waitForTimeout(3500)
+        await handleLoginModalIfPresent(page, { log, accountIndex })
+        await page.waitForTimeout(2500)
+        const postClickUrl = page.url()
+        const postClickShot = screenshotPath('03-after-add')
+        await page.screenshot({ path: postClickShot, fullPage: true })
+        log.info(`Post-Add URL: ${postClickUrl}`)
+
+        // Step 5: verify the hold by visiting /cart in a fresh tab.
+        log.info('Step 5: verify cart')
+        const { state: cartState, cartText, cartShot } = await verifyCartHold(ctx, {
+            siteNo,
+            startDate,
+            endDate,
+            screenshotPath,
+        })
+        log.info(`Cart state: ${cartState}`)
+
+        return {
+            ok: true,
+            ctx,
+            page,
+            postClickUrl,
+            postClickShot,
+            cartState,
+            cartShot,
+            cartText: cartText.slice(0, 1500),
+        }
+    } catch (err) {
+        log.error(`tryGrabCampsite error: ${err.message}`)
+        try { await page.screenshot({ path: screenshotPath('err'), fullPage: true }) } catch {}
+        return { ok: false, reason: err.message, ctx, page }
+    }
+}
+
+// Clear all holds for the given account. Used by tests so we can re-run
+// against the same slot. Same hard rule as permit-bot: NEVER from watch mode.
+export async function releaseCampspotCart({ accountIndex = 1, log = console } = {}) {
+    const acct = getAccount(accountIndex)
+    const ctx = await launchCampspotContext({ headless: false, accountIndex })
+    const page = await ctx.newPage()
+    let removed = 0
+    let state = 'unknown'
+    try {
+        await page.goto('https://www.recreation.gov/cart', { waitUntil: 'domcontentloaded', timeout: 20000 })
+        await page.waitForTimeout(2500)
+        await handleLoginModalIfPresent(page, { log, accountIndex })
+
+        const selectors = [
+            { role: 'button', name: /^remove$/i },
+            { css: '[aria-label*="remove" i]' },
+            { css: 'button:has-text("Remove")' },
+        ]
+        for (let pass = 0; pass < 5; pass++) {
+            let clicked = false
+            for (const sel of selectors) {
+                const loc = sel.role
+                    ? page.getByRole(sel.role, { name: sel.name }).first()
+                    : page.locator(sel.css).first()
+                if ((await loc.count()) === 0) continue
+                try {
+                    await loc.click({ timeout: 2000 })
+                    clicked = true
+                    removed++
+                    await page.waitForTimeout(800)
+                    const confirm = page.getByRole('button', { name: /^(remove|yes|confirm)$/i }).first()
+                    if ((await confirm.count()) > 0) {
+                        await confirm.click().catch(() => {})
+                        await page.waitForTimeout(800)
+                    }
+                    break
+                } catch {}
+            }
+            if (!clicked) break
+        }
+        const txt = await page.evaluate(() => document.body.innerText)
+        state = /your cart is empty/i.test(txt) ? 'empty' : 'has_items'
+        log.info(`releaseCampspotCart acct${accountIndex}: removed=${removed} state=${state}`)
+    } catch (err) {
+        log.error(`releaseCampspotCart failed: ${err.message}`)
+    } finally {
+        await ctx.close().catch(() => {})
+    }
+    return { removed, state, accountIndex, email: acct.email }
+}

--- a/campspot-bot/CampspotChecker.mjs
+++ b/campspot-bot/CampspotChecker.mjs
@@ -1,0 +1,157 @@
+import axios from 'axios'
+import { httpsAgent } from '../permit-bot/dnsBypass.mjs'
+import { findAllStays, rankStays, addDays } from './findStays.mjs'
+
+const USER_AGENT =
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 ' +
+    '(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'
+
+const MAX_BACKOFF_MS = 5 * 60 * 1000
+
+// Build the list of month-start ISO strings that cover [startDate..endDate].
+function monthStartsFor(startDate, endDate) {
+    const [sy, sm] = startDate.slice(0, 7).split('-').map(Number)
+    const [ey, em] = endDate.slice(0, 7).split('-').map(Number)
+    const out = []
+    let y = sy, m = sm
+    while (y < ey || (y === ey && m <= em)) {
+        const iso = new Date(Date.UTC(y, m - 1, 1)).toISOString()
+        out.push(iso)
+        m += 1
+        if (m > 12) { m = 1; y += 1 }
+    }
+    return out
+}
+
+// Merge per-month campsite payloads. rec.gov returns the same campsite keys
+// across months with date-keyed availabilities; we union the availabilities.
+function mergeMonths(target, src) {
+    for (const [id, site] of Object.entries(src || {})) {
+        if (!target[id]) {
+            target[id] = { ...site, availabilities: { ...(site.availabilities || {}) } }
+        } else {
+            target[id].availabilities = {
+                ...target[id].availabilities,
+                ...(site.availabilities || {}),
+            }
+        }
+    }
+}
+
+export default class CampspotChecker {
+    constructor({
+        campgroundId,
+        rangeStartDate, // YYYY-MM-DD inclusive
+        rangeEndDate,   // YYYY-MM-DD inclusive
+        targetWeekdays = ['Thu', 'Fri', 'Sat', 'Sun'],
+        maxNights = 4,
+        minNights = 1,
+        minPeople = 0,
+        log,
+    }) {
+        if (!campgroundId) throw new Error('CampspotChecker: campgroundId required')
+        if (!rangeStartDate || !rangeEndDate) throw new Error('CampspotChecker: rangeStartDate + rangeEndDate required')
+        this.campgroundId = campgroundId
+        this.rangeStartDate = rangeStartDate
+        this.rangeEndDate = rangeEndDate
+        this.targetWeekdays = targetWeekdays
+        this.maxNights = maxNights
+        this.minNights = minNights
+        this.minPeople = minPeople
+        this.log = log || console
+        this.backoffMs = 0
+        this.lastErrorReason = null
+        // dedup: { 'campsiteId|startDate|endDate' -> last seen ts }
+        this.lastSeenStays = new Map()
+    }
+
+    monthStarts() {
+        return monthStartsFor(this.rangeStartDate, this.rangeEndDate)
+    }
+
+    async pollOnce() {
+        const merged = {}
+        for (const ms of this.monthStarts()) {
+            const url = `https://www.recreation.gov/api/camps/availability/campground/${this.campgroundId}/month?start_date=${encodeURIComponent(ms)}`
+            const res = await axios.get(url, {
+                headers: { 'User-Agent': USER_AGENT, 'Accept': 'application/json' },
+                timeout: 15000,
+                httpsAgent,
+            })
+            mergeMonths(merged, res.data?.campsites)
+        }
+        return merged
+    }
+
+    // Returns { snapshot, newStays }. snapshot.stays is the full ranked list of
+    // every qualifying (campsiteId, dateRange) opportunity. newStays is the
+    // subset never seen before (dedup keyed by campsiteId|start|end), so
+    // callers can notify exactly once per new opening.
+    diff(campsitesPayload) {
+        const stays = findAllStays({
+            campsitesPayload,
+            rangeStartDate: this.rangeStartDate,
+            rangeEndDate: this.rangeEndDate,
+            targetWeekdays: this.targetWeekdays,
+            maxNights: this.maxNights,
+            minNights: this.minNights,
+            minPeople: this.minPeople,
+        })
+        const ranked = rankStays(stays)
+        const newStays = []
+        const currentKeys = new Set()
+        for (const s of ranked) {
+            const key = `${s.campsiteId}|${s.startDate}|${s.endDate}`
+            currentKeys.add(key)
+            if (!this.lastSeenStays.has(key)) {
+                newStays.push(s)
+            }
+            this.lastSeenStays.set(key, Date.now())
+        }
+        // Evict keys that aren't present anymore so they re-fire if they reopen.
+        for (const k of [...this.lastSeenStays.keys()]) {
+            if (!currentKeys.has(k)) this.lastSeenStays.delete(k)
+        }
+        return {
+            snapshot: {
+                fetchedAt: new Date().toISOString(),
+                rangeStartDate: this.rangeStartDate,
+                rangeEndDate: this.rangeEndDate,
+                stays: ranked,
+                campsiteCount: Object.keys(campsitesPayload || {}).length,
+            },
+            newStays,
+        }
+    }
+
+    handleError(err) {
+        const status = err.response?.status
+        const retryAfter = err.response?.headers?.['retry-after']
+        if (retryAfter) {
+            const sec = Number.parseInt(retryAfter, 10)
+            this.backoffMs = Number.isFinite(sec)
+                ? sec * 1000
+                : Math.min((this.backoffMs || 2000) * 2, MAX_BACKOFF_MS)
+            this.lastErrorReason = `Retry-After:${retryAfter}`
+        } else if (status === 429 || (status >= 500 && status < 600)) {
+            this.backoffMs = Math.min((this.backoffMs || 2000) * 2, MAX_BACKOFF_MS)
+            this.lastErrorReason = `HTTP ${status}`
+        } else if (['ECONNRESET', 'ETIMEDOUT', 'ECONNABORTED'].includes(err.code)) {
+            this.backoffMs = Math.min((this.backoffMs || 2000) * 2, MAX_BACKOFF_MS)
+            this.lastErrorReason = `Network ${err.code}`
+        } else {
+            this.lastErrorReason = err.message
+        }
+        this.log.error(`CampspotChecker error: ${this.lastErrorReason} (backoff ${this.backoffMs}ms)`)
+    }
+
+    resetBackoff() {
+        if (this.backoffMs > 0) {
+            this.log.info(`CampspotChecker recovered (backoff was ${this.backoffMs}ms)`)
+        }
+        this.backoffMs = 0
+        this.lastErrorReason = null
+    }
+}
+
+export { monthStartsFor, addDays }

--- a/campspot-bot/README.md
+++ b/campspot-bot/README.md
@@ -1,0 +1,65 @@
+# campspot-bot
+
+Sibling to `permit-bot/`. Watches a rec.gov **campground** (not permit) for
+Thu–Sun stays in a configurable window and (optionally) drives Playwright to
+add the slot to the user's cart so the hold sticks for 15 minutes.
+
+Target campground is set in `campspot-bot/config.json`. Defaults to Upper
+Pines (id `232447`), window `2026-06-22 → 2026-09-30`, weekdays Thu/Fri/Sat/Sun,
+max 4-night stays.
+
+Re-uses the rec.gov login from `permit-bot/.chromium-profile`, so run
+`node permit-bot/permit-bot.mjs login --account=1` once before any
+`--for-real` cart operation.
+
+## Commands
+
+```
+node campspot-bot/campspot-bot.mjs check
+  # one-shot scan of every campsite, prints qualifying Thu-Sun stays
+  # (ranked: longest first, earliest first, lowest site #).
+
+node campspot-bot/campspot-bot.mjs cart --site=068 --start=2026-09-10 --end=2026-09-14
+  # dry-run cart flow: opens browser, advances the calendar, locates the
+  # Available cell, screenshots. No clicks past the cell.
+
+node campspot-bot/campspot-bot.mjs cart --site=068 --start=2026-09-10 --end=2026-09-14 --for-real
+  # actually clicks "Add to Cart", verifies /cart hold, posts Discord with
+  # the cart screenshot.
+
+node campspot-bot/campspot-bot.mjs watch
+  # poll every config.pollIntervalMs; Discord/ntfy on NEW openings only.
+
+node campspot-bot/campspot-bot.mjs watch --auto-grab
+  # same, but fires the cart bot on the top-ranked new stay (one at a time;
+  # 1-hour cooldown per (site, dates) so we don't retry the same loss).
+
+node campspot-bot/campspot-bot.mjs release-cart [--account=N]
+  # test-only: clears every hold from the account's cart.
+```
+
+## How the cart flow works
+
+Validated 2026-06-22 via probe scripts (`probe-cart-ui.mjs`,
+`probe-click-avail.mjs`, `probe-after-click.mjs`):
+
+1. Open `/camping/campgrounds/<id>?startdate=X&enddate=Y` (Y is checkout).
+2. The page renders a `~10-day` per-site grid. Each cell is
+   `<button class="rec-availability-date">` with aria-label
+   `"<MonAbbr> <Day>, <Year> - Site <SiteNo> is available"` for bookable
+   nights, `"... is Reserved"` / `"... is Closed"` otherwise.
+3. Advance via `button[aria-label="Go Forward 5 Days"]` until the target
+   date column is rendered.
+4. Click the Available cell for the START date on the desired site. A
+   single click is enough — the page interprets the URL `startdate`/`enddate`
+   as the full trip, so "Add to Cart" appears immediately.
+5. Click `#add-cart-campsite` / `button:has-text("Add to Cart")`.
+6. Verify in a fresh `/cart` tab — body text should contain `Site <N>` and
+   the start date.
+
+## Env vars (loaded from `./.env` at repo root)
+
+- `REC_EMAIL` / `REC_PASSWORD` — account 1 credentials.
+- `CAMPSPOT_DISCORD_WEBHOOK_URL` (optional) — campspot-bot's own channel.
+  Falls back to `WEBHOOK_URL`.
+- `NTFY_TOPIC_URL` (optional) — same ntfy channel the other bots use.

--- a/campspot-bot/__tests__/CampspotChecker.test.mjs
+++ b/campspot-bot/__tests__/CampspotChecker.test.mjs
@@ -1,0 +1,78 @@
+import CampspotChecker, { monthStartsFor } from '../CampspotChecker.mjs'
+
+describe('monthStartsFor', () => {
+    test('inclusive across multi-month range', () => {
+        expect(monthStartsFor('2026-06-22', '2026-09-30')).toEqual([
+            new Date(Date.UTC(2026, 5, 1)).toISOString(),
+            new Date(Date.UTC(2026, 6, 1)).toISOString(),
+            new Date(Date.UTC(2026, 7, 1)).toISOString(),
+            new Date(Date.UTC(2026, 8, 1)).toISOString(),
+        ])
+    })
+
+    test('single-month range yields one start', () => {
+        expect(monthStartsFor('2026-07-15', '2026-07-20')).toEqual([
+            new Date(Date.UTC(2026, 6, 1)).toISOString(),
+        ])
+    })
+
+    test('crosses a year boundary', () => {
+        expect(monthStartsFor('2026-12-15', '2027-01-05')).toEqual([
+            new Date(Date.UTC(2026, 11, 1)).toISOString(),
+            new Date(Date.UTC(2027, 0, 1)).toISOString(),
+        ])
+    })
+})
+
+describe('CampspotChecker.diff', () => {
+    const baseConfig = {
+        campgroundId: '232447',
+        rangeStartDate: '2026-07-01',
+        rangeEndDate: '2026-07-31',
+        targetWeekdays: ['Thu', 'Fri', 'Sat', 'Sun'],
+        maxNights: 4,
+        minNights: 1,
+        log: { info: () => {}, warn: () => {}, error: () => {} },
+    }
+
+    const A = 'Available'
+
+    test('returns only NEW stays on second poll if state unchanged', () => {
+        const checker = new CampspotChecker(baseConfig)
+        const payload = {
+            '100': {
+                site: '044',
+                availabilities: {
+                    '2026-07-09T00:00:00Z': A,
+                    '2026-07-10T00:00:00Z': A,
+                },
+            },
+        }
+        const first = checker.diff(payload)
+        expect(first.snapshot.stays).toHaveLength(1)
+        expect(first.newStays).toHaveLength(1)
+        const second = checker.diff(payload)
+        expect(second.snapshot.stays).toHaveLength(1)
+        expect(second.newStays).toHaveLength(0)
+    })
+
+    test('re-fires when a stay disappears and reappears', () => {
+        const checker = new CampspotChecker(baseConfig)
+        const payloadOpen = {
+            '100': {
+                site: '044',
+                availabilities: { '2026-07-09T00:00:00Z': A, '2026-07-10T00:00:00Z': A },
+            },
+        }
+        const payloadClosed = {
+            '100': {
+                site: '044',
+                availabilities: { '2026-07-09T00:00:00Z': 'Reserved', '2026-07-10T00:00:00Z': 'Reserved' },
+            },
+        }
+        expect(checker.diff(payloadOpen).newStays).toHaveLength(1)
+        expect(checker.diff(payloadClosed).newStays).toHaveLength(0)
+        // After disappearing it should re-emit as new on next reappearance.
+        expect(checker.diff(payloadOpen).newStays).toHaveLength(1)
+    })
+})

--- a/campspot-bot/__tests__/findStays.test.mjs
+++ b/campspot-bot/__tests__/findStays.test.mjs
@@ -1,0 +1,330 @@
+import {
+    findStaysForSite,
+    findAllStays,
+    rankStays,
+    weekdayOf,
+    addDays,
+    isoUtcMidnight,
+} from '../findStays.mjs'
+
+const A = 'Available'
+const R = 'Reserved'
+const C = 'Closed'
+
+// 2026-07-09 = Thu, 2026-07-10 = Fri, 2026-07-11 = Sat, 2026-07-12 = Sun, 2026-07-13 = Mon.
+function withAvail(dates) {
+    const out = {}
+    for (const [date, status] of Object.entries(dates)) {
+        out[isoUtcMidnight(date)] = status
+    }
+    return out
+}
+
+describe('weekday math', () => {
+    test('weekdayOf knows 2026-07-09 is a Thursday', () => {
+        expect(weekdayOf('2026-07-09')).toBe('Thu')
+        expect(weekdayOf('2026-07-10')).toBe('Fri')
+        expect(weekdayOf('2026-07-11')).toBe('Sat')
+        expect(weekdayOf('2026-07-12')).toBe('Sun')
+        expect(weekdayOf('2026-07-13')).toBe('Mon')
+    })
+
+    test('addDays crosses month boundary', () => {
+        expect(addDays('2026-07-31', 1)).toBe('2026-08-01')
+        expect(addDays('2026-08-01', -1)).toBe('2026-07-31')
+    })
+})
+
+describe('findStaysForSite', () => {
+    const targetWeekdays = ['Thu', 'Fri', 'Sat', 'Sun']
+
+    test('full Thu-Sun stay (4 nights) when everything available', () => {
+        const availabilities = withAvail({
+            '2026-07-09': A, // Thu
+            '2026-07-10': A, // Fri
+            '2026-07-11': A, // Sat
+            '2026-07-12': A, // Sun
+            '2026-07-13': R, // Mon
+        })
+        const stays = findStaysForSite({
+            campsiteId: '100',
+            availabilities,
+            rangeStartDate: '2026-07-01',
+            rangeEndDate: '2026-07-31',
+            targetWeekdays,
+            maxNights: 4,
+        })
+        expect(stays).toHaveLength(1)
+        expect(stays[0]).toMatchObject({
+            campsiteId: '100',
+            startDate: '2026-07-09',
+            endDate: '2026-07-13',
+            nights: 4,
+        })
+    })
+
+    test('cap at maxNights — Thu only when maxNights=1', () => {
+        const availabilities = withAvail({
+            '2026-07-09': A, // Thu
+            '2026-07-10': A, // Fri
+            '2026-07-11': A, // Sat
+            '2026-07-12': A, // Sun
+        })
+        const stays = findStaysForSite({
+            campsiteId: '100',
+            availabilities,
+            rangeStartDate: '2026-07-01',
+            rangeEndDate: '2026-07-31',
+            targetWeekdays,
+            maxNights: 1,
+        })
+        // Each consecutive cap-length run is emitted, then the next day starts
+        // a new run. With maxNights=1 we get 4 stays back-to-back.
+        expect(stays).toHaveLength(4)
+        expect(stays.map(s => s.startDate)).toEqual([
+            '2026-07-09', '2026-07-10', '2026-07-11', '2026-07-12',
+        ])
+        expect(stays.every(s => s.nights === 1)).toBe(true)
+    })
+
+    test('breaks the run on a Reserved night', () => {
+        const availabilities = withAvail({
+            '2026-07-09': A, // Thu
+            '2026-07-10': R, // Fri
+            '2026-07-11': A, // Sat
+            '2026-07-12': A, // Sun
+        })
+        const stays = findStaysForSite({
+            campsiteId: '100',
+            availabilities,
+            rangeStartDate: '2026-07-01',
+            rangeEndDate: '2026-07-31',
+            targetWeekdays,
+            maxNights: 4,
+        })
+        expect(stays).toHaveLength(2)
+        expect(stays[0]).toMatchObject({ startDate: '2026-07-09', nights: 1 })
+        expect(stays[1]).toMatchObject({ startDate: '2026-07-11', nights: 2, endDate: '2026-07-13' })
+    })
+
+    test('skips Monday-Wednesday because they are not in target weekdays', () => {
+        const availabilities = withAvail({
+            '2026-07-12': A, // Sun
+            '2026-07-13': A, // Mon (target NOT set)
+            '2026-07-14': A, // Tue
+            '2026-07-15': A, // Wed
+            '2026-07-16': A, // Thu
+            '2026-07-17': A, // Fri
+        })
+        const stays = findStaysForSite({
+            campsiteId: '100',
+            availabilities,
+            rangeStartDate: '2026-07-01',
+            rangeEndDate: '2026-07-31',
+            targetWeekdays,
+            maxNights: 4,
+        })
+        // Sun (1 night) then Thu-Fri (2 nights). Mon/Tue/Wed break the run.
+        expect(stays).toHaveLength(2)
+        expect(stays[0]).toMatchObject({ startDate: '2026-07-12', nights: 1 })
+        expect(stays[1]).toMatchObject({ startDate: '2026-07-16', nights: 2 })
+    })
+
+    test('missing availability entries break the run (treated as not Available)', () => {
+        const availabilities = withAvail({
+            '2026-07-09': A, // Thu
+            // 2026-07-10 missing
+            '2026-07-11': A, // Sat
+        })
+        const stays = findStaysForSite({
+            campsiteId: '100',
+            availabilities,
+            rangeStartDate: '2026-07-01',
+            rangeEndDate: '2026-07-31',
+            targetWeekdays,
+            maxNights: 4,
+        })
+        expect(stays.map(s => `${s.startDate}/${s.nights}`)).toEqual([
+            '2026-07-09/1', '2026-07-11/1',
+        ])
+    })
+
+    test('Closed status does not qualify', () => {
+        const availabilities = withAvail({
+            '2026-07-09': A,
+            '2026-07-10': C,
+            '2026-07-11': A,
+        })
+        const stays = findStaysForSite({
+            campsiteId: '100',
+            availabilities,
+            rangeStartDate: '2026-07-01',
+            rangeEndDate: '2026-07-31',
+            targetWeekdays: ['Thu', 'Fri', 'Sat', 'Sun'],
+            maxNights: 4,
+        })
+        expect(stays).toHaveLength(2)
+    })
+
+    test('minNights filter drops 1-nighters', () => {
+        const availabilities = withAvail({
+            '2026-07-09': A, // Thu — 1 night
+            '2026-07-10': R, // Fri reserved
+            '2026-07-11': A, // Sat
+            '2026-07-12': A, // Sun — 2 nights
+        })
+        const stays = findStaysForSite({
+            campsiteId: '100',
+            availabilities,
+            rangeStartDate: '2026-07-01',
+            rangeEndDate: '2026-07-31',
+            targetWeekdays: ['Thu', 'Fri', 'Sat', 'Sun'],
+            maxNights: 4,
+            minNights: 2,
+        })
+        expect(stays).toHaveLength(1)
+        expect(stays[0]).toMatchObject({ startDate: '2026-07-11', nights: 2 })
+    })
+
+    test('respects range bounds (does not pick up Aug from a Jul-only window)', () => {
+        const availabilities = withAvail({
+            '2026-07-30': A, // Thu
+            '2026-07-31': A, // Fri
+            '2026-08-01': A, // Sat — outside range
+        })
+        const stays = findStaysForSite({
+            campsiteId: '100',
+            availabilities,
+            rangeStartDate: '2026-07-01',
+            rangeEndDate: '2026-07-31',
+            targetWeekdays: ['Thu', 'Fri', 'Sat', 'Sun'],
+            maxNights: 4,
+        })
+        expect(stays).toHaveLength(1)
+        expect(stays[0]).toMatchObject({ startDate: '2026-07-30', nights: 2, endDate: '2026-08-01' })
+    })
+})
+
+describe('findAllStays + rankStays', () => {
+    test('aggregates across campsites and surfaces metadata', () => {
+        const payload = {
+            '100': {
+                site: '044',
+                loop: 'Upper Pines',
+                campsite_type: 'STANDARD NONELECTRIC',
+                max_num_people: 6,
+                availabilities: withAvail({
+                    '2026-07-09': A,
+                    '2026-07-10': A,
+                }),
+            },
+            '101': {
+                site: '045',
+                loop: 'Upper Pines',
+                campsite_type: 'STANDARD NONELECTRIC',
+                max_num_people: 6,
+                availabilities: withAvail({
+                    '2026-07-09': A,
+                    '2026-07-10': A,
+                    '2026-07-11': A,
+                    '2026-07-12': A,
+                }),
+            },
+        }
+        const stays = findAllStays({
+            campsitesPayload: payload,
+            rangeStartDate: '2026-07-01',
+            rangeEndDate: '2026-07-31',
+            targetWeekdays: ['Thu', 'Fri', 'Sat', 'Sun'],
+            maxNights: 4,
+        })
+        expect(stays).toHaveLength(2)
+        const ranked = rankStays(stays)
+        // 4-nighter ranks first, then 2-nighter.
+        expect(ranked[0]).toMatchObject({ campsiteId: '101', nights: 4 })
+        expect(ranked[1]).toMatchObject({ campsiteId: '100', nights: 2 })
+        // Metadata propagated:
+        expect(ranked[0].siteNo).toBe('045')
+        expect(ranked[0].maxPeople).toBe(6)
+    })
+
+    test('minPeople drops sites whose max_num_people is below threshold', () => {
+        const payload = {
+            '100': { // capacity 4 — fails minPeople=6
+                site: '044',
+                max_num_people: 4,
+                availabilities: withAvail({
+                    '2026-07-09': A, '2026-07-10': A, '2026-07-11': A, '2026-07-12': A,
+                }),
+            },
+            '101': { // capacity 6 — passes
+                site: '045',
+                max_num_people: 6,
+                availabilities: withAvail({
+                    '2026-07-09': A, '2026-07-10': A,
+                }),
+            },
+            '102': { // capacity unknown — kept (better to alert than silently drop)
+                site: '046',
+                availabilities: withAvail({ '2026-07-11': A, '2026-07-12': A }),
+            },
+        }
+        const stays = findAllStays({
+            campsitesPayload: payload,
+            rangeStartDate: '2026-07-01',
+            rangeEndDate: '2026-07-31',
+            targetWeekdays: ['Thu', 'Fri', 'Sat', 'Sun'],
+            maxNights: 4,
+            minPeople: 6,
+        })
+        const sites = stays.map(s => s.siteNo).sort()
+        expect(sites).toEqual(['045', '046'])
+    })
+
+    test('minPeople=0 keeps every site (filter off)', () => {
+        const payload = {
+            '100': {
+                site: '044',
+                max_num_people: 2,
+                availabilities: withAvail({ '2026-07-09': A, '2026-07-10': A }),
+            },
+        }
+        const stays = findAllStays({
+            campsitesPayload: payload,
+            rangeStartDate: '2026-07-01',
+            rangeEndDate: '2026-07-31',
+            targetWeekdays: ['Thu', 'Fri', 'Sat', 'Sun'],
+            maxNights: 4,
+            minPeople: 0,
+        })
+        expect(stays).toHaveLength(1)
+    })
+
+    test('rank ties break by earliest startDate then lowest site number', () => {
+        const payload = {
+            '100': {
+                site: '044',
+                availabilities: withAvail({ '2026-07-16': A, '2026-07-17': A }),
+            },
+            '101': {
+                site: '045',
+                availabilities: withAvail({ '2026-07-09': A, '2026-07-10': A }),
+            },
+            '102': {
+                site: '003',
+                availabilities: withAvail({ '2026-07-09': A, '2026-07-10': A }),
+            },
+        }
+        const stays = findAllStays({
+            campsitesPayload: payload,
+            rangeStartDate: '2026-07-01',
+            rangeEndDate: '2026-07-31',
+            targetWeekdays: ['Thu', 'Fri', 'Sat', 'Sun'],
+            maxNights: 4,
+        })
+        const ranked = rankStays(stays)
+        // All same length (2 nights). Earlier date wins. Within same date,
+        // lower siteNo wins.
+        expect(ranked.map(s => s.siteNo)).toEqual(['003', '045', '044'])
+    })
+})

--- a/campspot-bot/campspot-bot.mjs
+++ b/campspot-bot/campspot-bot.mjs
@@ -1,0 +1,327 @@
+#!/usr/bin/env node
+import * as dotenv from 'dotenv'
+dotenv.config()
+
+import { readFileSync } from 'node:fs'
+import { createReadStream } from 'node:fs'
+import path from 'node:path'
+import axios from 'axios'
+import FormData from 'form-data'
+
+import CampspotChecker from './CampspotChecker.mjs'
+import { tryGrabCampsite, releaseCampspotCart } from './CampspotCartBot.mjs'
+import { httpsAgent } from '../permit-bot/dnsBypass.mjs'
+
+const log = {
+    info: (msg) => console.log(`[${new Date().toISOString()}] ${msg}`),
+    warn: (msg) => console.warn(`[${new Date().toISOString()}] WARN ${msg}`),
+    error: (msg) => console.error(`[${new Date().toISOString()}] ERR  ${msg}`),
+}
+
+// Routing: a campspot-specific Discord webhook keeps these alerts from
+// drowning out the legacy campsite-checker and permit-bot channels. Falls back
+// to the campspot-checker webhook, then nothing.
+const DISCORD_WEBHOOK_URL = process.env.CAMPSPOT_DISCORD_WEBHOOK_URL
+    || process.env.WEBHOOK_URL
+    || null
+const NTFY_TOPIC_URL = process.env.NTFY_TOPIC_URL || null
+
+function loadConfig() {
+    const p = path.resolve('./campspot-bot/config.json')
+    return JSON.parse(readFileSync(p, 'utf-8'))
+}
+
+async function discordPush(text, screenshotPath = null) {
+    if (!DISCORD_WEBHOOK_URL) {
+        log.warn('No CAMPSPOT_DISCORD_WEBHOOK_URL / WEBHOOK_URL in .env — skipping Discord push.')
+        return { ok: false, status: 0 }
+    }
+    try {
+        if (screenshotPath) {
+            const form = new FormData()
+            form.append('payload_json', JSON.stringify({ content: text }), { contentType: 'application/json' })
+            form.append('file1', createReadStream(screenshotPath), {
+                filename: path.basename(screenshotPath),
+                contentType: 'image/png',
+            })
+            const res = await axios.post(DISCORD_WEBHOOK_URL, form, {
+                timeout: 20000,
+                httpsAgent,
+                headers: form.getHeaders(),
+                maxBodyLength: Infinity,
+                maxContentLength: Infinity,
+            })
+            return { ok: true, status: res.status }
+        }
+        const res = await axios.post(DISCORD_WEBHOOK_URL, { content: text }, { timeout: 10000, httpsAgent })
+        return { ok: true, status: res.status }
+    } catch (err) {
+        log.warn(`Discord push failed: ${err.message}`)
+        return { ok: false, status: err.response?.status ?? 0, error: err.message }
+    }
+}
+
+async function pushNtfy(title, message, opts = {}) {
+    if (!NTFY_TOPIC_URL) return
+    try {
+        const headers = {
+            'Title': title.replace(/[\r\n]+/g, ' ').slice(0, 250),
+            'Priority': opts.priority || '5',
+            'Tags': opts.tags || 'tent,mountain',
+        }
+        if (opts.click) headers['Click'] = opts.click
+        if (opts.actions?.length) {
+            headers['Actions'] = opts.actions.map(a =>
+                `view, ${a.label}, ${a.url}, clear=true`
+            ).join('; ')
+        }
+        await axios.post(NTFY_TOPIC_URL, message, { headers, timeout: 5000, httpsAgent })
+    } catch (err) {
+        log.warn(`ntfy push failed: ${err.message}`)
+    }
+}
+
+function fmtStay(s) {
+    const range = `${s.startDate} → ${s.endDate} (${s.nights}n)`
+    const meta = [s.loop, s.campsiteType, s.maxPeople ? `max ${s.maxPeople}` : null].filter(Boolean).join(' · ')
+    return `Site ${s.siteNo || s.campsiteId}: ${range}${meta ? `  [${meta}]` : ''}`
+}
+
+function bookingUrl(campgroundId, s) {
+    return `https://www.recreation.gov/camping/campgrounds/${campgroundId}?startdate=${s.startDate}&enddate=${s.endDate}`
+}
+
+async function cmdCheck() {
+    const config = loadConfig()
+    const checker = new CampspotChecker({
+        campgroundId: config.campgroundId,
+        rangeStartDate: config.rangeStartDate,
+        rangeEndDate: config.rangeEndDate,
+        targetWeekdays: config.targetWeekdays,
+        maxNights: config.maxNights,
+        minNights: config.minNights,
+        minPeople: config.minPeople,
+        log,
+    })
+    log.info(`check: cg=${config.campgroundId} window=${config.rangeStartDate}..${config.rangeEndDate} weekdays=${config.targetWeekdays.join(',')} nights=${config.minNights}-${config.maxNights} minPeople=${config.minPeople}`)
+    const payload = await checker.pollOnce()
+    const { snapshot } = checker.diff(payload)
+    log.info(`Scanned ${snapshot.campsiteCount} campsites, found ${snapshot.stays.length} qualifying stays.`)
+    for (const s of snapshot.stays.slice(0, 50)) {
+        console.log('  ' + fmtStay(s))
+    }
+    if (snapshot.stays.length === 0) {
+        console.log('  (no qualifying availability — campground fully booked across the window)')
+    }
+}
+
+async function cmdCart({ overrides = {}, dryRun = true, accountIndex = 1 } = {}) {
+    const config = loadConfig()
+    if (!overrides.siteNo || !overrides.startDate || !overrides.endDate) {
+        console.error('Usage: cart --site=068 --start=2026-06-22 --end=2026-06-23 [--for-real] [--account=N]')
+        process.exit(2)
+    }
+    log.info(`cart: site=${overrides.siteNo} ${overrides.startDate}→${overrides.endDate} dryRun=${dryRun} account=${accountIndex}`)
+    const result = await tryGrabCampsite({
+        campgroundId: config.campgroundId,
+        campsiteId: overrides.campsiteId || null,
+        siteNo: overrides.siteNo,
+        startDate: overrides.startDate,
+        endDate: overrides.endDate,
+        dryRun,
+        accountIndex,
+        log,
+    })
+    log.info(`Result: ${JSON.stringify({ ok: result.ok, reason: result.reason, cartState: result.cartState })}`)
+    if (!dryRun && result.ok) {
+        const lines = [
+            result.cartState === 'held' ? '✅ **CAMPSPOT CART HOLD CONFIRMED**' :
+            result.cartState === 'empty' ? '⚠️ Add to Cart clicked, but cart is EMPTY' :
+            '⚠️ Add to Cart clicked — cart state unclear, see screenshot',
+            `**Campground:** ${config.campgroundName} (${config.campgroundId})`,
+            `**Site:** ${overrides.siteNo}`,
+            `**Dates:** ${overrides.startDate} → ${overrides.endDate}`,
+            `**Cart state:** ${result.cartState}`,
+            `**Action needed:** open https://www.recreation.gov/cart and complete checkout within 15 min (or Remove if this was a test).`,
+        ]
+        await discordPush(lines.join('\n'), result.cartShot || result.postClickShot)
+    }
+    if (result.ctx) {
+        await new Promise(r => setTimeout(r, 30_000))
+        await result.ctx.close().catch(() => {})
+    }
+}
+
+async function cmdRelease({ accountIndex = 1 } = {}) {
+    const r = await releaseCampspotCart({ accountIndex, log })
+    log.info(`removed=${r.removed} state=${r.state}`)
+}
+
+// watch: poll continuously, notify on new openings. With --auto-grab, fires
+// CampspotCartBot on the highest-ranked new stay (sequentially — one cart at
+// a time so we don't trigger captchas).
+async function cmdWatch({ autoGrab = false, accountIndex = 1 } = {}) {
+    const config = loadConfig()
+    const checker = new CampspotChecker({
+        campgroundId: config.campgroundId,
+        rangeStartDate: config.rangeStartDate,
+        rangeEndDate: config.rangeEndDate,
+        targetWeekdays: config.targetWeekdays,
+        maxNights: config.maxNights,
+        minNights: config.minNights,
+        minPeople: config.minPeople,
+        log,
+    })
+    log.info(`watch: cg=${config.campgroundId} window=${config.rangeStartDate}..${config.rangeEndDate} ` +
+        `weekdays=${config.targetWeekdays.join(',')} nights=${config.minNights}-${config.maxNights} ` +
+        `minPeople=${config.minPeople} poll=${config.pollIntervalMs}ms autoGrab=${autoGrab}`)
+
+    let cycle = 0
+    let cartInFlight = false
+    const recentlyAttempted = new Map() // key -> ts
+
+    // Startup ping.
+    await discordPush([
+        '🟢 **campspot-bot watch started**',
+        `**Campground:** ${config.campgroundName} (${config.campgroundId})`,
+        `**Window:** ${config.rangeStartDate} → ${config.rangeEndDate}`,
+        `**Weekdays:** ${config.targetWeekdays.join(', ')} · **Nights:** ${config.minNights}–${config.maxNights}`,
+        `**Min capacity:** ${config.minPeople || 'any'} people`,
+        `**Poll:** ${config.pollIntervalMs}ms · **Auto-cart:** ${autoGrab ? 'ON' : 'off'}`,
+    ].join('\n'))
+
+    while (true) {
+        cycle++
+        const t0 = Date.now()
+        try {
+            const payload = await checker.pollOnce()
+            const { snapshot, newStays } = checker.diff(payload)
+            checker.resetBackoff()
+            log.info(`cycle ${cycle}: ${snapshot.stays.length} stays (${newStays.length} new)`)
+
+            if (newStays.length > 0) {
+                const header = `🏕️ **${newStays.length} new ${config.campgroundName} opening(s)**`
+                const body = newStays.slice(0, 10).map(s => {
+                    const url = bookingUrl(config.campgroundId, s)
+                    return `• ${fmtStay(s)} — ${url}`
+                }).join('\n')
+                await discordPush(`${header}\n${body}`)
+
+                const best = newStays[0]
+                await pushNtfy(
+                    `Upper Pines: ${best.nights}n on ${best.startDate}`,
+                    `Site ${best.siteNo} — ${best.startDate} → ${best.endDate}`,
+                    {
+                        click: bookingUrl(config.campgroundId, best),
+                        priority: '5',
+                        tags: 'tent,rotating_light',
+                    },
+                )
+
+                if (autoGrab && !cartInFlight) {
+                    // Take the best new stay we haven't tried in the last hour.
+                    const ONE_HOUR = 60 * 60 * 1000
+                    const candidate = newStays.find(s => {
+                        const key = `${s.campsiteId}|${s.startDate}|${s.endDate}`
+                        const last = recentlyAttempted.get(key) || 0
+                        return Date.now() - last > ONE_HOUR
+                    })
+                    if (candidate) {
+                        cartInFlight = true
+                        const key = `${candidate.campsiteId}|${candidate.startDate}|${candidate.endDate}`
+                        recentlyAttempted.set(key, Date.now())
+                        ;(async () => {
+                            try {
+                                log.info(`auto-grab: ${fmtStay(candidate)}`)
+                                const r = await tryGrabCampsite({
+                                    campgroundId: config.campgroundId,
+                                    campsiteId: candidate.campsiteId,
+                                    siteNo: candidate.siteNo,
+                                    startDate: candidate.startDate,
+                                    endDate: candidate.endDate,
+                                    dryRun: false,
+                                    accountIndex,
+                                    log,
+                                })
+                                const status = r.cartState === 'held'
+                                    ? '✅ **CART HOLD CONFIRMED**'
+                                    : `⚠️ auto-grab finished — cart state: ${r.cartState ?? r.reason ?? 'unknown'}`
+                                await discordPush([
+                                    status,
+                                    `**Site ${candidate.siteNo}** — ${candidate.startDate} → ${candidate.endDate} (${candidate.nights}n)`,
+                                    `**Cart:** https://www.recreation.gov/cart`,
+                                    `**Booking link:** ${bookingUrl(config.campgroundId, candidate)}`,
+                                ].join('\n'), r.cartShot || r.postClickShot)
+                                if (r.ctx) {
+                                    await new Promise(rr => setTimeout(rr, 30_000))
+                                    await r.ctx.close().catch(() => {})
+                                }
+                            } catch (err) {
+                                log.error(`auto-grab error: ${err.stack || err.message}`)
+                                await discordPush(`❌ auto-grab error: ${err.message}`)
+                            } finally {
+                                cartInFlight = false
+                            }
+                        })()
+                    }
+                }
+            }
+        } catch (err) {
+            checker.handleError(err)
+        }
+        const elapsed = Date.now() - t0
+        const sleepMs = Math.max(0, config.pollIntervalMs - elapsed) + checker.backoffMs
+        await new Promise(r => setTimeout(r, sleepMs))
+    }
+}
+
+const subcommand = process.argv[2]
+const rest = process.argv.slice(3)
+const flags = new Set(rest.filter(a => a.startsWith('--') && !a.includes('=')))
+const kv = Object.fromEntries(
+    rest.filter(a => a.startsWith('--') && a.includes('='))
+        .map(a => {
+            const [k, ...v] = a.slice(2).split('=')
+            return [k, v.join('=')]
+        })
+)
+
+;(async () => {
+    try {
+        const accountIndex = kv.account ? Number(kv.account) : 1
+        switch (subcommand) {
+            case 'check':
+                await cmdCheck(); break
+            case 'cart':
+                await cmdCart({
+                    accountIndex,
+                    dryRun: !flags.has('--for-real'),
+                    overrides: {
+                        siteNo: kv.site,
+                        campsiteId: kv.campsite,
+                        startDate: kv.start,
+                        endDate: kv.end,
+                    },
+                }); break
+            case 'release-cart':
+                await cmdRelease({ accountIndex }); break
+            case 'watch':
+                await cmdWatch({ autoGrab: flags.has('--auto-grab'), accountIndex }); break
+            default:
+                console.log(`Usage:
+  node campspot-bot/campspot-bot.mjs check                                  # one-shot availability scan
+  node campspot-bot/campspot-bot.mjs cart --site=068 --start=YYYY-MM-DD --end=YYYY-MM-DD [--for-real] [--account=N]
+                                                                            # dry-run by default; --for-real adds to cart
+  node campspot-bot/campspot-bot.mjs release-cart [--account=N]             # clear holds (test cleanup)
+  node campspot-bot/campspot-bot.mjs watch [--auto-grab] [--account=N]      # poll continuously, notify; --auto-grab fires the cart bot
+
+Edit campspot-bot/config.json for campgroundId / weekday filter / window.
+Re-uses the permit-bot rec.gov session — run \`node permit-bot/permit-bot.mjs login\` first.
+`)
+                process.exit(1)
+        }
+    } catch (err) {
+        log.error(err.stack || err.message)
+        process.exit(2)
+    }
+})()

--- a/campspot-bot/config.json
+++ b/campspot-bot/config.json
@@ -1,0 +1,13 @@
+{
+  "campgroundId": "232447",
+  "campgroundName": "Upper Pines Campground",
+  "park": "Yosemite",
+  "rangeStartDate": "2026-06-22",
+  "rangeEndDate": "2026-09-30",
+  "targetWeekdays": ["Thu", "Fri", "Sat", "Sun"],
+  "maxNights": 4,
+  "minNights": 2,
+  "minPeople": 6,
+  "pollIntervalMs": 60000,
+  "autoCart": false
+}

--- a/campspot-bot/findStays.mjs
+++ b/campspot-bot/findStays.mjs
@@ -1,0 +1,153 @@
+// Find consecutive Available nights that all fall on one of `weekdays`, up to
+// `maxNights` long. Returns the LONGEST stay per disjoint run; runs longer than
+// `maxNights` are split into back-to-back stays so the operator still sees
+// every cartable opportunity.
+//
+// site.availabilities is the rec.gov payload shape, keyed by ISO UTC midnight:
+//   { '2026-07-09T00:00:00Z': 'Available', '2026-07-10T00:00:00Z': 'Reserved', ... }
+//
+// rangeStartDate / rangeEndDate are 'YYYY-MM-DD' inclusive. Dates outside the
+// payload (or not in target weekdays, or not 'Available') break the run.
+//
+// Returned stay shape:
+//   { campsiteId, startDate, endDate (checkout), nights, nightDates: ['YYYY-MM-DD',...] }
+// endDate is checkout day (startDate + nights), matching rec.gov's `enddate`
+// URL param convention.
+
+const WEEKDAY_NAMES = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
+
+export function isoUtcMidnight(yyyymmdd) {
+    return `${yyyymmdd}T00:00:00Z`
+}
+
+export function weekdayOf(yyyymmdd) {
+    const d = new Date(`${yyyymmdd}T00:00:00Z`)
+    return WEEKDAY_NAMES[d.getUTCDay()]
+}
+
+export function addDays(yyyymmdd, n) {
+    const ms = Date.parse(`${yyyymmdd}T00:00:00Z`) + n * 86400000
+    return new Date(ms).toISOString().slice(0, 10)
+}
+
+export function eachDate(startDate, endDate) {
+    const out = []
+    let d = startDate
+    while (d <= endDate) {
+        out.push(d)
+        d = addDays(d, 1)
+    }
+    return out
+}
+
+// Status values considered "Available" — anything else (Reserved, Closed,
+// Not Reservable Management, NYR, missing) breaks the run.
+const AVAILABLE = new Set(['Available'])
+
+// Greedy left-to-right walk. When the current run reaches maxNights, we emit
+// it and reset *without consuming the current night*, so the next day can
+// start a fresh run (which only happens when the next day is also a target
+// weekday + available — i.e. very long Thu-Sun stretches across weeks).
+// Actually that's a non-issue: in practice Thu-Sun runs cap at 4 nights, and
+// the next valid weekday (Thu) is 3 days later. The emit-then-reset path is
+// for safety; the common case is run terminated by Monday.
+export function findStaysForSite({
+    campsiteId,
+    availabilities,
+    rangeStartDate,
+    rangeEndDate,
+    targetWeekdays,
+    maxNights,
+    minNights = 1,
+}) {
+    const weekdaySet = new Set(targetWeekdays)
+    const stays = []
+    let runStart = null
+    let runDates = []
+
+    const flush = () => {
+        if (runStart && runDates.length >= minNights) {
+            const last = runDates[runDates.length - 1]
+            stays.push({
+                campsiteId,
+                startDate: runStart,
+                endDate: addDays(last, 1),
+                nights: runDates.length,
+                nightDates: [...runDates],
+            })
+        }
+        runStart = null
+        runDates = []
+    }
+
+    for (const date of eachDate(rangeStartDate, rangeEndDate)) {
+        const status = availabilities[isoUtcMidnight(date)]
+        const qualifies = AVAILABLE.has(status) && weekdaySet.has(weekdayOf(date))
+        if (!qualifies) {
+            flush()
+            continue
+        }
+        if (runStart == null) runStart = date
+        runDates.push(date)
+        if (runDates.length >= maxNights) {
+            flush() // emit cap-length run; the very next day continues a new run if it qualifies
+        }
+    }
+    flush()
+    return stays
+}
+
+// Scan every campsite in the payload and return all qualifying stays.
+// Caller decides ranking (e.g. longest first).
+//
+// minPeople: skip sites whose max_num_people is below the threshold. If a site
+// is missing max_num_people we KEEP it (null > threshold is treated as
+// unknown-capacity — better to alert and let the human filter than to silently
+// drop). Set minPeople = 0 to disable the filter.
+export function findAllStays({
+    campsitesPayload,
+    rangeStartDate,
+    rangeEndDate,
+    targetWeekdays,
+    maxNights,
+    minNights = 1,
+    minPeople = 0,
+}) {
+    const all = []
+    for (const [campsiteId, site] of Object.entries(campsitesPayload || {})) {
+        if (minPeople > 0 && Number.isFinite(site.max_num_people) && site.max_num_people < minPeople) {
+            continue
+        }
+        const stays = findStaysForSite({
+            campsiteId,
+            availabilities: site.availabilities || {},
+            rangeStartDate,
+            rangeEndDate,
+            targetWeekdays,
+            maxNights,
+            minNights,
+        })
+        for (const s of stays) {
+            all.push({
+                ...s,
+                siteNo: site.site || null,
+                loop: site.loop || null,
+                campsiteType: site.campsite_type || null,
+                maxPeople: site.max_num_people ?? null,
+            })
+        }
+    }
+    return all
+}
+
+// Score: longer stays preferred; ties broken by earliest start date, then
+// lowest site number for stable ordering. Higher score = better.
+export function rankStays(stays) {
+    return [...stays].sort((a, b) => {
+        if (b.nights !== a.nights) return b.nights - a.nights
+        if (a.startDate !== b.startDate) return a.startDate < b.startDate ? -1 : 1
+        const an = parseInt(a.siteNo || a.campsiteId, 10) || 0
+        const bn = parseInt(b.siteNo || b.campsiteId, 10) || 0
+        return an - bn
+    })
+}

--- a/campspot-bot/mechanism.html
+++ b/campspot-bot/mechanism.html
@@ -1,0 +1,296 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>campspot-bot — Mechanism &amp; Workflow</title>
+<style>
+  :root {
+    --bg: #0f1115;
+    --panel: #161a23;
+    --panel-2: #1c2230;
+    --ink: #e7ecf3;
+    --ink-dim: #98a2b3;
+    --accent: #6ee7b7;
+    --accent-2: #fbbf24;
+    --accent-3: #818cf8;
+    --warn: #f87171;
+    --line: #2a3142;
+    --code: #c6d3e6;
+  }
+  html, body { background: var(--bg); color: var(--ink); }
+  body {
+    font: 14.5px/1.55 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", sans-serif;
+    margin: 0; padding: 32px 24px 64px;
+    max-width: 1100px; margin-inline: auto;
+  }
+  h1 { font-size: 26px; margin: 0 0 4px; letter-spacing: -0.01em; }
+  h2 { font-size: 16px; margin: 36px 0 12px; color: var(--accent); letter-spacing: 0.04em; text-transform: uppercase; }
+  p, li { color: var(--ink); }
+  .lede { color: var(--ink-dim); margin: 0 0 12px; }
+  code, kbd, pre {
+    font: 12.5px/1.5 "SF Mono", ui-monospace, "JetBrains Mono", Menlo, monospace;
+    color: var(--code);
+  }
+  code { background: var(--panel-2); padding: 1px 5px; border-radius: 4px; }
+  pre {
+    background: var(--panel);
+    border: 1px solid var(--line);
+    padding: 12px 14px;
+    border-radius: 6px;
+    overflow-x: auto;
+    margin: 8px 0 0;
+  }
+  .panel {
+    background: var(--panel);
+    border: 1px solid var(--line);
+    border-radius: 8px;
+    padding: 16px 18px;
+    margin: 8px 0;
+  }
+  .row { display: flex; gap: 12px; flex-wrap: wrap; }
+  .row > * { flex: 1 1 0; min-width: 240px; }
+
+  /* Architecture cards */
+  .arch { display: grid; grid-template-columns: 1fr 18px 1fr 18px 1fr; align-items: stretch; gap: 0; }
+  .arch .box {
+    background: var(--panel);
+    border: 1px solid var(--line);
+    border-radius: 8px;
+    padding: 12px 14px;
+  }
+  .arch .arrow {
+    display: flex; align-items: center; justify-content: center;
+    color: var(--ink-dim); font-weight: 700;
+  }
+  .box h3 { margin: 0 0 6px; font-size: 14px; color: var(--accent-3); letter-spacing: 0.03em; text-transform: uppercase; }
+  .box .meta { color: var(--ink-dim); font-size: 12.5px; }
+
+  /* Calendar */
+  .cal { display: grid; grid-template-columns: repeat(7, 1fr); gap: 4px; max-width: 420px; }
+  .cal .h, .cal .d {
+    background: var(--panel-2);
+    border: 1px solid var(--line);
+    border-radius: 5px;
+    padding: 8px 4px;
+    text-align: center;
+    font-size: 12px;
+  }
+  .cal .h { color: var(--ink-dim); font-weight: 600; }
+  .cal .d.out { opacity: 0.3; }
+  .cal .d.target { border-color: var(--accent); background: rgba(110,231,183,0.12); }
+  .cal .d.avail { background: rgba(110,231,183,0.35); color: #062a1d; font-weight: 700; }
+  .cal .d.res { background: var(--panel); color: var(--ink-dim); }
+  .cal .legend { grid-column: 1 / -1; color: var(--ink-dim); font-size: 12px; padding-top: 8px; }
+
+  /* Step list */
+  ol.steps { padding-left: 22px; }
+  ol.steps li { margin: 6px 0; }
+  ol.steps li code { color: var(--accent-2); }
+
+  /* Run modes table */
+  table { border-collapse: collapse; width: 100%; margin-top: 4px; }
+  th, td {
+    text-align: left; padding: 10px 12px; border-bottom: 1px solid var(--line);
+    vertical-align: top;
+  }
+  th { color: var(--ink-dim); font-size: 12px; letter-spacing: 0.04em; text-transform: uppercase; }
+  td.cmd code { color: var(--accent-2); white-space: nowrap; }
+
+  .pill {
+    display: inline-block; padding: 2px 8px; border-radius: 999px;
+    background: var(--panel-2); color: var(--ink-dim); font-size: 11px;
+    border: 1px solid var(--line); margin-right: 6px;
+  }
+  .pill.live { background: rgba(110,231,183,0.12); color: var(--accent); border-color: rgba(110,231,183,0.4); }
+  .pill.warn { background: rgba(248,113,113,0.12); color: var(--warn); border-color: rgba(248,113,113,0.4); }
+
+  .seq {
+    display: grid;
+    grid-template-columns: 90px 1fr;
+    gap: 6px 16px;
+    align-items: start;
+  }
+  .seq .t { color: var(--accent-2); font: 12px/1.4 "SF Mono", ui-monospace, monospace; padding-top: 2px; }
+  .seq .e { padding-bottom: 6px; border-bottom: 1px dashed var(--line); }
+
+  .footer { color: var(--ink-dim); font-size: 12px; margin-top: 36px; }
+</style>
+</head>
+<body>
+
+<h1>campspot-bot</h1>
+<p class="lede">
+Watches <strong>Upper Pines Campground</strong> (rec.gov id <code>232447</code>) for
+Thu&ndash;Sun stays through Sep&nbsp;30, and (optionally) drives a real Chrome to
+<strong>add the slot to your cart</strong> so the 15-minute hold protects it while you check out.
+</p>
+
+<h2>1. Architecture</h2>
+<div class="arch">
+  <div class="box">
+    <h3>CampspotChecker</h3>
+    <div class="meta">
+      Hits the public availability API every <code>pollIntervalMs</code>.
+      Merges multiple months. Memorizes stays it's already seen so the same
+      opening doesn't fire twice.
+    </div>
+    <pre>GET .../api/camps/availability/
+   campground/232447/month
+   ?start_date=2026-07-01T00:00:00Z</pre>
+  </div>
+  <div class="arrow">&rarr;</div>
+  <div class="box">
+    <h3>findStays</h3>
+    <div class="meta">
+      Pure date logic. Walks each campsite's daily map and emits
+      consecutive runs of <em>Available</em> nights that fall entirely on
+      Thu/Fri/Sat/Sun, capped at 4 nights. Ranks longest&nbsp;&rarr;&nbsp;earliest.
+    </div>
+    <pre>stay = { siteNo, startDate,
+         endDate, nights }</pre>
+  </div>
+  <div class="arrow">&rarr;</div>
+  <div class="box">
+    <h3>CampspotCartBot</h3>
+    <div class="meta">
+      Playwright-driven Chromium that re-uses the rec.gov session you logged in
+      with via <code>permit-bot</code>. Clicks the Available cell, then
+      <strong>Add to Cart</strong>, then verifies <code>/cart</code>.
+    </div>
+    <pre>page.click('[aria-label=
+  "Jul 9, 2026 - Site 068
+   is available"]')</pre>
+  </div>
+</div>
+
+<h2>2. What counts as a "stay"</h2>
+<div class="row">
+  <div class="panel">
+    <p class="lede">A stay is the <strong>longest contiguous run of Available nights</strong> within Thu&ndash;Sun, capped at 4. Each run also gets sliced so no run exceeds the cap.</p>
+    <ul>
+      <li>Mon/Tue/Wed break the run automatically &mdash; they're not in <code>targetWeekdays</code>.</li>
+      <li><code>Reserved</code>, <code>Closed</code>, and missing entries break the run.</li>
+      <li>Ranking: most nights first, then earliest start, then lowest site number.</li>
+      <li>Dedup: a stay only fires once per "open period." If it closes &amp; reopens, it fires again.</li>
+    </ul>
+  </div>
+  <div>
+    <div class="cal">
+      <div class="h">Mon</div><div class="h">Tue</div><div class="h">Wed</div>
+      <div class="h">Thu</div><div class="h">Fri</div><div class="h">Sat</div><div class="h">Sun</div>
+      <div class="d out">6</div><div class="d out">7</div><div class="d out">8</div>
+      <div class="d avail">9</div><div class="d avail">10</div><div class="d avail">11</div><div class="d avail">12</div>
+      <div class="d out">13</div><div class="d out">14</div><div class="d out">15</div>
+      <div class="d target">16</div><div class="d res">17</div><div class="d target">18</div><div class="d target">19</div>
+      <div class="legend">
+        <span class="pill live">avail night</span>
+        <span class="pill">target weekday, reserved/missing</span>
+        <span class="pill">non-target weekday</span>
+        <br>
+        Jul 9&ndash;12 emits a <strong>4-night stay</strong>. Jul 16 is alone (Fri reserved breaks the run). Jul 18&ndash;19 is a 2-nighter.
+      </div>
+    </div>
+  </div>
+</div>
+
+<h2>3. Poll loop (every <code>pollIntervalMs</code>)</h2>
+<div class="panel">
+<div class="seq">
+  <div class="t">+0ms</div><div class="e">Fetch each month in the configured window (one HTTP request per month).</div>
+  <div class="t">+~400ms</div><div class="e">Merge months &rarr; <code>findAllStays</code> &rarr; <code>rankStays</code>.</div>
+  <div class="t"></div><div class="e">Compare against <code>lastSeenStays</code>. Anything not seen since last poll is <em>new</em>.</div>
+  <div class="t">on new</div><div class="e">Discord push: <code>{header, bullets per stay, booking URLs}</code>. ntfy push with tap-action to the rec.gov page.</div>
+  <div class="t">on new + <code>--auto-grab</code></div><div class="e">Fire <code>CampspotCartBot</code> on the top-ranked new stay (one at a time; 1-hour cooldown per (site, dates) so we don't retry the same loss).</div>
+  <div class="t">on 429 / 5xx</div><div class="e">Exponential backoff up to 5 min. Honors <code>Retry-After</code>. Stops hammering the API.</div>
+  <div class="t">sleep</div><div class="e">Wait <code>pollIntervalMs</code> minus elapsed, plus backoff. Repeat.</div>
+</div>
+</div>
+
+<h2>4. The cart automation, step by step</h2>
+<div class="panel">
+<ol class="steps">
+  <li>Open <code>https://www.recreation.gov/camping/campgrounds/232447?startdate=&lt;X&gt;&amp;enddate=&lt;Y&gt;</code> in a headed Chromium (same profile as permit-bot so the rec.gov cookie carries over).</li>
+  <li>If a re-auth modal pops, fill it via <code>handleLoginModalIfPresent</code> from permit-bot.</li>
+  <li>Advance the calendar via <code>button[aria-label="Go Forward 5 Days"]</code> until the target date column is in the grid (up to 60 advances &asymp; 300 days).</li>
+  <li>Locate the cell:<br><code>[aria-label="Sep 11, 2026 - Site 068 is available" i]</code></li>
+  <li>Click it. A single click is enough because the page derives the trip range from the URL params.</li>
+  <li>Click <code>#add-cart-campsite</code> ("Add to Cart"). Re-runs the login-modal handler in case rec.gov demands a fresh auth.</li>
+  <li>Open <code>/cart</code> in a fresh tab. Verify body text contains <code>Site &lt;N&gt;</code> AND the start date. Screenshot.</li>
+  <li>Post outcome to Discord with the cart screenshot attached.</li>
+</ol>
+<p class="lede" style="margin-top:14px">If the cell isn't found after the calendar advances, the bot exits with <code>cell_not_available</code> instead of clicking blindly &mdash; the slot was taken between the API poll and the click.</p>
+</div>
+
+<h2>5. Run modes</h2>
+<table>
+  <thead><tr><th>Command</th><th>What happens</th></tr></thead>
+  <tbody>
+    <tr>
+      <td class="cmd"><code>check</code></td>
+      <td>One-shot scan. Prints every qualifying stay (sorted). No browser, no notifications. <span class="pill">safe, read-only</span></td>
+    </tr>
+    <tr>
+      <td class="cmd"><code>cart --site=068 --start=&hellip; --end=&hellip;</code></td>
+      <td>Dry-run. Opens Chromium, advances calendar, locates the cell, screenshots. Does NOT click Add&nbsp;to&nbsp;Cart. <span class="pill">safe</span></td>
+    </tr>
+    <tr>
+      <td class="cmd"><code>cart &hellip; --for-real</code></td>
+      <td>Same flow, but clicks Add&nbsp;to&nbsp;Cart and verifies the hold. <span class="pill warn">creates a real 15-min hold</span></td>
+    </tr>
+    <tr>
+      <td class="cmd"><code>watch</code></td>
+      <td>Polls forever. Discord/ntfy on new openings. No cart. <span class="pill live">recommended start mode</span></td>
+    </tr>
+    <tr>
+      <td class="cmd"><code>watch --auto-grab</code></td>
+      <td>Polls forever. On a new opening, fires <code>--for-real</code> automatically on the top-ranked stay. <span class="pill warn">creates real holds</span></td>
+    </tr>
+    <tr>
+      <td class="cmd"><code>release-cart</code></td>
+      <td>Test cleanup. Clicks every Remove button on <code>/cart</code>.</td>
+    </tr>
+  </tbody>
+</table>
+
+<h2>6. Config knobs (<code>campspot-bot/config.json</code>)</h2>
+<pre>{
+  "campgroundId": "232447",            // Upper Pines
+  "rangeStartDate": "2026-06-22",      // window inclusive
+  "rangeEndDate":   "2026-09-30",
+  "targetWeekdays": ["Thu","Fri","Sat","Sun"],
+  "maxNights": 4,                      // cap on stay length
+  "minNights": 1,                      // drop shorter stays (raise to 2 to skip 1-nighters)
+  "pollIntervalMs": 60000,             // 60s default
+  "autoCart": false                    // informational; CLI flag controls the actual mode
+}</pre>
+
+<h2>7. What I checked vs. what's untested live</h2>
+<div class="row">
+  <div class="panel">
+    <strong style="color:var(--accent)">Confirmed against rec.gov on 2026-06-22:</strong>
+    <ul>
+      <li>API payload shape and that the multi-month merge works.</li>
+      <li>Cell aria-label format: <code>"Sep 8, 2026 - Site 046 is available"</code> (lowercase available).</li>
+      <li>Calendar "Go Forward 5 Days" navigation lands on the target date.</li>
+      <li>Single click on the Available cell makes <strong>Add to Cart</strong> appear.</li>
+      <li>Dry-run cart succeeded against a live slot (Site 068, Jun 22).</li>
+    </ul>
+  </div>
+  <div class="panel">
+    <strong style="color:var(--warn)">Not yet exercised live:</strong>
+    <ul>
+      <li>The actual Add&nbsp;to&nbsp;Cart click and <code>/cart</code> hold verification. Selectors are the same as the dry-run path plus the login-modal handler, but the for-real path will only get fully validated the first time a real opening fires.</li>
+    </ul>
+    <p>Right now the campground is essentially fully booked through Sep&nbsp;30, so the first real test will happen when something opens up.</p>
+  </div>
+</div>
+
+<p class="footer">
+Source: <code>campspot-bot/</code> on branch <code>worktree-campspot-bot</code>.
+Re-uses the rec.gov login from <code>permit-bot/.chromium-profile</code> &mdash; run
+<code>node permit-bot/permit-bot.mjs login --account=1</code> once before any
+<code>--for-real</code> cart op.
+</p>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary

- New **campspot-bot** sibling to permit-bot: polls rec.gov for Upper Pines (id 232447) Thu–Sun stays and (with `--auto-grab`) clicks through the booking grid to lock the 15-minute cart hold automatically.
- Stay-selection logic is pure and testable — greedy maximal Thu–Sun runs capped at `maxNights`, with `minPeople` filter for site capacity (defaults: 2–4 nights, ≥6 capacity).
- Cart automation re-uses permit-bot's chromium profile + login-modal handler, so a single `permit-bot login` covers both bots.

## Validation

Smoke-tested live on 2026-06-22: bot caught a new opening (Site 192 / Sun Sep 13), advanced the calendar, handled a mid-flow rec.gov re-auth modal, and produced a real cart hold (since released via `release-cart`). The original verifier had a substring-match false negative (cart formats it as `192, Upper Pines …` not `Site 192`); fixed in this PR.

200 → 202 tests passing, including 5 dedup / multi-month / party-size edge cases.

## Files of note

- `campspot-bot/findStays.mjs` — pure date logic + ranking
- `campspot-bot/CampspotChecker.mjs` — API poller + dedup
- `campspot-bot/CampspotCartBot.mjs` — Playwright automation
- `campspot-bot/campspot-bot.mjs` — CLI (check / cart / watch / watch --auto-grab / release-cart)
- `campspot-bot/mechanism.html` — visual workflow walkthrough
- `campspot-bot/README.md` — usage + selectors notes

## Test plan

- [x] `npm test -- campspot-bot` passes (17 new + all existing)
- [x] `node campspot-bot/campspot-bot.mjs check` returns ranked qualifying stays from the live API
- [x] Dry-run `cart` against a live Available cell finds + screenshots it
- [x] Live `watch --auto-grab` end-to-end: detect → advance calendar → click cell → handle login modal → real cart hold
- [ ] First real `held` report from the fixed verifier (will happen on the next live opening; current code path matches the cart text format we observed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)