### PR TITLE
fix(campspot-bot): multi-night range selection + wrong-trip detection

### DIFF
--- a/campspot-bot/CampspotCartBot.mjs
+++ b/campspot-bot/CampspotCartBot.mjs
@@ -97,38 +97,75 @@ export async function findAvailableCell(page, { siteNo, date }) {
     return (await cell.count()) > 0 ? cell : null
 }
 
+// Step back one calendar day from endDate (the checkout) to get the last
+// NIGHT's date. Multi-night range selection clicks both the first-night cell
+// and the last-night cell.
+export function lastNightOf(startDate, endDate) {
+    const sMs = Date.parse(`${startDate}T00:00:00Z`)
+    const eMs = Date.parse(`${endDate}T00:00:00Z`)
+    if (!Number.isFinite(sMs) || !Number.isFinite(eMs) || eMs <= sMs) return null
+    const lastNightMs = eMs - 86400000
+    return new Date(lastNightMs).toISOString().slice(0, 10)
+}
+
+function humanDate(yyyymmdd) {
+    const [y, m, d] = yyyymmdd.split('-').map(Number)
+    return `${MONTH_NAMES[m - 1]} ${d}, ${y}`
+}
+
 // One-shot: navigate to /cart in a fresh tab and read the body text to verify
-// the hold. Returns { state: 'held' | 'empty' | 'has_items_but_not_target' |
-// 'unknown', cartText, cartShot }.
+// the hold. Returns { state, cartText, cartShot, observed }.
 //
 // rec.gov cart format (verified 2026-06-22 by a real auto-grab):
-//   "192, Upper Pines RV NONELECTRIC"
-//   "Check-In Date: Sun Sep 13, 2026"
-// So we match site number + a human-formatted date ("Sep 13") rather than the
-// ISO start date. Two-signal AND-match avoids false-positives from a stale
-// prior hold for a different (site, date).
+//   "003, Upper Pines STANDARD NONELECTRIC"
+//   "Check-In Date: Thu Jun 25, 2026"
+//   "Check-Out Date: Fri Jun 26, 2026"
+//
+// States:
+//   'held'        → cart has site + correct check-in AND check-out
+//   'wrong_trip'  → cart has site + correct check-in but wrong check-out
+//                   (the multi-night bug from 2026-06-22: rec.gov gave us 1
+//                    night instead of N because we only clicked one cell).
+//                   Caller should release this hold immediately so it doesn't
+//                   squat on the user's account.
+//   'has_items_but_not_target' → cart has SOMETHING but not our site/date
+//   'empty'       → empty cart
+//   'unknown'     → couldn't parse
 async function verifyCartHold(ctx, { siteNo, startDate, endDate, screenshotPath }) {
     const cartPage = await ctx.newPage()
     let cartShot = null
     let state = 'unknown'
     let cartText = ''
+    const observed = { checkIn: null, checkOut: null }
     try {
         await cartPage.goto('https://www.recreation.gov/cart', { waitUntil: 'domcontentloaded', timeout: 20000 })
         await cartPage.waitForTimeout(2500)
         cartShot = screenshotPath('cart')
         await cartPage.screenshot({ path: cartShot, fullPage: true })
         cartText = await cartPage.evaluate(() => document.body.innerText)
-        const lower = cartText.toLowerCase()
-        const [sy, sm, sd] = startDate.split('-').map(Number)
-        const humanDate = `${MONTH_NAMES[sm - 1]} ${sd}, ${sy}`.toLowerCase()
+
+        // Pull the literal check-in / check-out lines so we can report what we
+        // actually got, not just true/false. Pattern: "Check-In Date: Thu Jun 25, 2026".
+        const ciMatch = cartText.match(/Check-In Date:\s*\w+\s+(\w+)\s+(\d+),\s+(\d{4})/i)
+        const coMatch = cartText.match(/Check-Out Date:\s*\w+\s+(\w+)\s+(\d+),\s+(\d{4})/i)
+        if (ciMatch) observed.checkIn = `${ciMatch[1]} ${ciMatch[2]}, ${ciMatch[3]}`
+        if (coMatch) observed.checkOut = `${coMatch[1]} ${coMatch[2]}, ${coMatch[3]}`
+
+        const startHuman = humanDate(startDate)
+        const endHuman = humanDate(endDate)
         const sitePattern = new RegExp(`(?:^|\\W)${siteNo.replace(/^0+/, '0*')}(?:,|\\s)`, 'i')
+        const siteOk = sitePattern.test(cartText)
+        const startOk = observed.checkIn?.toLowerCase() === startHuman.toLowerCase()
+        const endOk = observed.checkOut?.toLowerCase() === endHuman.toLowerCase()
+
         if (/your cart is empty/i.test(cartText)) state = 'empty'
-        else if (sitePattern.test(cartText) && lower.includes(humanDate)) state = 'held'
+        else if (siteOk && startOk && endOk) state = 'held'
+        else if (siteOk && startOk && !endOk) state = 'wrong_trip'
         else if (/cart/i.test(cartText)) state = 'has_items_but_not_target'
     } finally {
         await cartPage.close().catch(() => {})
     }
-    return { state, cartText, cartShot }
+    return { state, cartText, cartShot, observed }
 }
 
 // Add a single (campsiteId, siteNo, startDate, endDate) stay to the cart.
@@ -189,10 +226,30 @@ export async function tryGrabCampsite({
             return { ok: true, dryRun: true, ctx, page }
         }
 
-        // Step 3: click the start cell to select the site for this trip range.
-        log.info('Step 3: click Available cell')
+        // Step 3a: click the start cell — this picks the first night.
+        log.info('Step 3a: click start cell (first night)')
         await cell.click()
-        await page.waitForTimeout(1500)
+        await page.waitForTimeout(1200)
+
+        // Step 3b: for multi-night stays, ALSO click the last-night cell.
+        // (Verified 2026-06-22 by a real auto-grab gone wrong: a single click
+        // on the start cell is interpreted as a 1-night stay regardless of
+        // URL `enddate`. To get N nights, click both endpoints — rec.gov
+        // range-selects the span between.)
+        const lastNight = lastNightOf(startDate, endDate)
+        if (lastNight && lastNight !== startDate) {
+            log.info(`Step 3b: click last-night cell (${lastNight}) for range select`)
+            await advanceCalendarTo(page, lastNight, { log, maxAdvances: 6 })
+            const endCell = await findAvailableCell(page, { siteNo, date: lastNight })
+            if (!endCell) {
+                log.warn(`No Available cell for last-night ${lastNight} on site ${siteNo} — slot likely partially taken`)
+                await page.screenshot({ path: screenshotPath('err-no-end-cell'), fullPage: true })
+                return { ok: false, reason: 'last_night_cell_missing', ctx, page }
+            }
+            await endCell.scrollIntoViewIfNeeded().catch(() => {})
+            await endCell.click()
+            await page.waitForTimeout(1200)
+        }
         await page.screenshot({ path: screenshotPath('02-after-cell-click'), fullPage: true })
 
         // Step 4: click "Add to Cart". The button appears after the cell click
@@ -223,13 +280,27 @@ export async function tryGrabCampsite({
 
         // Step 5: verify the hold by visiting /cart in a fresh tab.
         log.info('Step 5: verify cart')
-        const { state: cartState, cartText, cartShot } = await verifyCartHold(ctx, {
+        const { state: cartState, cartText, cartShot, observed } = await verifyCartHold(ctx, {
             siteNo,
             startDate,
             endDate,
             screenshotPath,
         })
-        log.info(`Cart state: ${cartState}`)
+        log.info(`Cart state: ${cartState} (observed checkIn=${observed.checkIn}, checkOut=${observed.checkOut})`)
+
+        // Step 6: if rec.gov gave us the wrong trip (e.g. 1 night instead of
+        // 4 because we only clicked the start cell), release the hold
+        // immediately so it doesn't squat on the account for 15 minutes for
+        // the wrong reservation.
+        if (cartState === 'wrong_trip') {
+            log.warn(`wrong_trip detected — releasing hold (wanted ${startDate}→${endDate}, got checkOut=${observed.checkOut})`)
+            try {
+                const r = await releaseCampspotCart({ accountIndex, log })
+                log.info(`released stale wrong_trip hold: removed=${r.removed} state=${r.state}`)
+            } catch (err) {
+                log.warn(`auto-release after wrong_trip failed: ${err.message}`)
+            }
+        }
 
         return {
             ok: true,
@@ -240,6 +311,7 @@ export async function tryGrabCampsite({
             cartState,
             cartShot,
             cartText: cartText.slice(0, 1500),
+            observed,
         }
     } catch (err) {
         log.error(`tryGrabCampsite error: ${err.message}`)

--- a/campspot-bot/__tests__/CampspotCartBot.test.mjs
+++ b/campspot-bot/__tests__/CampspotCartBot.test.mjs
@@ -1,0 +1,27 @@
+import { lastNightOf } from '../CampspotCartBot.mjs'
+
+describe('lastNightOf', () => {
+    test('4-night Thu-Sun stay → last night is Sun', () => {
+        // Jun 25 (Thu) → Jun 29 (Mon checkout) = nights Thu/Fri/Sat/Sun = last night Sun Jun 28.
+        expect(lastNightOf('2026-06-25', '2026-06-29')).toBe('2026-06-28')
+    })
+
+    test('2-night Fri-Sat stay', () => {
+        expect(lastNightOf('2026-07-10', '2026-07-12')).toBe('2026-07-11')
+    })
+
+    test('1-night stay → last night equals first night (caller skips range click)', () => {
+        // The CartBot watches for `lastNight !== startDate` before doing the
+        // second click — this is the early-return signal.
+        expect(lastNightOf('2026-06-22', '2026-06-23')).toBe('2026-06-22')
+    })
+
+    test('null on invalid / reversed dates', () => {
+        expect(lastNightOf('2026-06-29', '2026-06-25')).toBeNull()
+        expect(lastNightOf('not-a-date', '2026-06-29')).toBeNull()
+    })
+
+    test('crosses month boundary', () => {
+        expect(lastNightOf('2026-06-30', '2026-07-03')).toBe('2026-07-02')
+    })
+})

--- a/campspot-bot/campspot-bot.mjs
+++ b/campspot-bot/campspot-bot.mjs
@@ -244,14 +244,30 @@ async function cmdWatch({ autoGrab = false, accountIndex = 1 } = {}) {
                                     log,
                                 })
                                 const status = r.cartState === 'held'
-                                    ? '✅ **CART HOLD CONFIRMED**'
-                                    : `⚠️ auto-grab finished — cart state: ${r.cartState ?? r.reason ?? 'unknown'}`
+                                    ? '✅ **CART HOLD CONFIRMED** — go check out!'
+                                    : r.cartState === 'wrong_trip'
+                                        ? `⚠️ **WRONG TRIP** — rec.gov gave us check-out ${r.observed?.checkOut} (wanted ${candidate.endDate}). Hold auto-released.`
+                                        : `⚠️ auto-grab finished — cart state: ${r.cartState ?? r.reason ?? 'unknown'}`
                                 await discordPush([
                                     status,
                                     `**Site ${candidate.siteNo}** — ${candidate.startDate} → ${candidate.endDate} (${candidate.nights}n)`,
                                     `**Cart:** https://www.recreation.gov/cart`,
                                     `**Booking link:** ${bookingUrl(config.campgroundId, candidate)}`,
                                 ].join('\n'), r.cartShot || r.postClickShot)
+                                // Louder phone notification ONLY on a real hold — Discord pushes
+                                // lag 5-15s on mobile, ntfy delivers in ~1s. The 15-min cart
+                                // timer is short; the difference matters.
+                                if (r.cartState === 'held') {
+                                    await pushNtfy(
+                                        `HOLD: ${config.campgroundName} site ${candidate.siteNo}`,
+                                        `${candidate.startDate} → ${candidate.endDate} (${candidate.nights}n) — check out within 15 min!`,
+                                        {
+                                            click: 'https://www.recreation.gov/cart',
+                                            priority: 'max',
+                                            tags: 'tent,white_check_mark,rotating_light',
+                                        },
+                                    )
+                                }
                                 if (r.ctx) {
                                     await new Promise(rr => setTimeout(rr, 30_000))
                                     await r.ctx.close().catch(() => {})


### PR DESCRIPTION
## Summary

Tonight's auto-grab reported a 4-night Thu–Sun hold on Upper Pines site 003, but the cart screenshot showed it actually only held **Jun 25 (1 night, \$36)**. Two real bugs:

1. **Multi-night ≠ one click.** rec.gov's per-day cells are single-night selectors. A single click on the start cell + an `enddate` URL param does NOT range-select; you have to click both the first-night cell AND the last-night cell.
2. **Verifier was too loose** — only matched site number + check-in date, never checked the check-out, so the 1-night hold passed as "held".

This PR ships:

- Range-select: click start cell, then click last-night cell (= `endDate − 1`). Advances the calendar between clicks if the last-night column is off-screen.
- New `wrong_trip` cart state: check-in matches but check-out doesn't. Bot auto-releases that hold immediately so a misaligned 1-night reservation doesn't squat on the account for 15 minutes.
- Verifier parses literal `Check-In Date` / `Check-Out Date` lines from the cart and AND-matches against `(siteNo, startDate, endDate)`. No more silent "held" on the wrong trip length.
- Watch-loop Discord message distinguishes `held` / `wrong_trip` / other, and a real `held` fires a **max-priority ntfy push** with `Click=https://www.recreation.gov/cart` so you get a phone-rattling notification (Discord pushes lag 5–15s on mobile; ntfy delivers in ~1s — the 15-min cart timer is short and that difference matters).
- 5 new unit tests on `lastNightOf` covering month boundary, 1-night skip case, reversed dates, invalid input.

## Files

- `campspot-bot/CampspotCartBot.mjs` — `lastNightOf`, range-select, new verifier, `wrong_trip` auto-release
- `campspot-bot/campspot-bot.mjs` — watch loop wiring (Discord copy + ntfy push)
- `campspot-bot/__tests__/CampspotCartBot.test.mjs` — new

## Test plan

- [x] `npm test` — 207 / 207 passing (5 new tests)
- [x] Bot already restarted with this code; logged a clean 1-cycle startup before this PR was opened
- [ ] First real fire after merge: should produce a 4-night hold OR `wrong_trip` + auto-release (no silent 1-night lies)

🤖 Generated with [Claude Code](https://claude.com/claude-code)