### PR TITLE
feat(campspot-bot): 20s polling + booking POST capture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,5 @@ campspot-bot/.screenshots/
 campspot-bot/.traces/
 campspot-bot/logs/
 campspot-bot/.chromium-probe/
+campspot-bot/.captures/
 campspot-bot/state/

--- a/campspot-bot/CampspotCartBot.mjs
+++ b/campspot-bot/CampspotCartBot.mjs
@@ -21,6 +21,7 @@
 // for-real mode and returns a result object the CLI logs / Discords.
 import { chromium } from 'playwright'
 import path from 'node:path'
+import { writeFileSync } from 'node:fs'
 import { mkdir } from 'node:fs/promises'
 import { getAccount, handleLoginModalIfPresent } from '../permit-bot/CartBot.mjs'
 import { resolveForChromium } from '../permit-bot/dnsBypass.mjs'
@@ -354,7 +355,42 @@ export async function warmCampspotWindow({
     const page = await ctx.newPage()
     page.setDefaultTimeout(15000)
     const shotsDir = path.resolve('./campspot-bot/.screenshots')
+    const capturesDir = path.resolve('./campspot-bot/.captures')
     await mkdir(shotsDir, { recursive: true })
+    await mkdir(capturesDir, { recursive: true })
+
+    // Intel collection: every fire, the warm browser ends up POSTing the real
+    // booking request to /api/camps/reservations/campgrounds/<id>/multi (the
+    // shape was reverse-engineered out of the rec.gov bundle). We don't yet
+    // call the API directly because the request body's exact field names stay
+    // minified — so we capture the body + auth header off the wire here and
+    // dump it to campspot-bot/.captures/. Future PR: replay the captured POST
+    // in parallel with the UI clicks to shave the 3s click-latency off fires.
+    //
+    // Listener stays attached for the warm window's lifetime; one file per
+    // capture so multiple successful fires accumulate evidence.
+    const capturedRequests = []
+    page.on('request', (req) => {
+        const url = req.url()
+        if (!/\/reservations\/campgrounds\/\d+\/multi/i.test(url)) return
+        if (req.method() !== 'POST') return
+        const stamp = new Date().toISOString().replace(/[:.]/g, '-')
+        const file = path.join(capturesDir, `booking-post-${stamp}.json`)
+        const record = {
+            ts: new Date().toISOString(),
+            url,
+            method: req.method(),
+            headers: req.headers(),
+            postData: req.postData(),
+        }
+        capturedRequests.push(record)
+        try {
+            writeFileSync(file, JSON.stringify(record, null, 2))
+            log.info(`${tag} CAPTURED booking POST → ${file}`)
+        } catch (err) {
+            log.warn(`${tag} capture write failed: ${err.message}`)
+        }
+    })
 
     await page.goto(baseUrl, { waitUntil: 'domcontentloaded' })
     await page.waitForTimeout(3000)

--- a/campspot-bot/config.json
+++ b/campspot-bot/config.json
@@ -8,6 +8,6 @@
   "maxNights": 4,
   "minNights": 2,
   "minPeople": 6,
-  "pollIntervalMs": 60000,
+  "pollIntervalMs": 20000,
   "autoCart": false
 }


### PR DESCRIPTION
## Summary

Two upgrades aimed at closing the race window. Last night's site 080 fire confirmed we're losing slots to faster bots — the 3-second cell-click latency between \"API recheck says OK\" and \"click last-night cell\" was enough for another party to snipe the tail night.

### 1. Polling 60s → 20s

`pollIntervalMs` from `60000` → `20000`. Detection latency goes from \"up to 60s after the slot opens\" to \"up to 20s.\" Tonight's volume was ~1 detection per 9h, so the 3× traffic is well below anything that would trip rec.gov's WAF — and the existing 429 backoff handler covers us if it does spike.

### 2. Booking-POST capture (intel for follow-up direct-API path)

Found the endpoint by grepping the rec.gov bundle:

```
POST /api/camps/reservations/campgrounds/{campgroundId}/multi
Body: { reservations: [...], gate_a? }
```

Full reservation-object field names are minified hard, so the cleanest path is to capture the request off the wire during a real fire. New `page.on('request')` listener in `warmCampspotWindow` writes every matching POST to `campspot-bot/.captures/booking-post-<timestamp>.json` (URL, method, headers, postData).

**Why this matters:** once we have a captured POST, a follow-up PR can replay it directly via axios in parallel with the UI click path. That kills the 3s click-latency that lost tonight's race. We don't ship the direct-API path in this PR because building it speculatively against a minified bundle without a reference capture is fragile — better to wait for one real fire and copy exactly.

## Test plan

- [x] `npm test` — 212 / 212
- [x] Bot restarted with 20s polling + listener attached. Log shows `poll=20000ms autoGrab=true`
- [ ] Next real fire (whenever): expect a `.captures/booking-post-*.json` file alongside the existing screenshot trail

🤖 Generated with [Claude Code](https://claude.com/claude-code)