### PR TITLE
feat(campspot-bot): --capture-on-partial flag for booking POST harvest

### DIFF
--- a/campspot-bot/CampspotCartBot.mjs
+++ b/campspot-bot/CampspotCartBot.mjs
@@ -185,6 +185,14 @@ async function performBookingFlow(ctx, page, {
     accountIndex = 1,
     screenshotPath,
     log = console,
+    // captureOnPartial: when the last-night cell disappears mid-flow we
+    // normally bail (correct, refuses to lock a wrong-trip). When this flag is
+    // true AND no booking-POST capture has been recorded yet, we go ahead and
+    // click Add to Cart on the start-cell-only selection so the network
+    // interceptor finally sees the real request. The wrong_trip detector then
+    // releases the resulting 1-night hold automatically. One capture is enough
+    // — caller is expected to flip the flag back off after a capture lands.
+    captureOnPartial = false,
 }) {
     // Step 1: advance calendar to startDate.
     log.info('Step 1: advance calendar grid to target date')
@@ -219,19 +227,30 @@ async function performBookingFlow(ctx, page, {
     // (A single click on the start cell is interpreted as a 1-night stay
     // regardless of URL `enddate`. To get N nights, click both endpoints —
     // rec.gov range-selects the span between.)
+    let partialCapture = false
     const lastNight = lastNightOf(startDate, endDate)
     if (lastNight && lastNight !== startDate) {
         log.info(`Step 3b: click last-night cell (${lastNight}) for range select`)
         await advanceCalendarTo(page, lastNight, { log, maxAdvances: 6 })
         const endCell = await findAvailableCell(page, { siteNo, date: lastNight })
         if (!endCell) {
-            log.warn(`No Available cell for last-night ${lastNight} on site ${siteNo} — slot likely partially taken`)
             await page.screenshot({ path: screenshotPath('err-no-end-cell'), fullPage: true }).catch(() => {})
-            return { ok: false, reason: 'last_night_cell_missing', ctx, page }
+            if (captureOnPartial) {
+                log.warn(`No Available cell for last-night ${lastNight} on site ${siteNo} — proceeding with 1-night capture (captureOnPartial=true)`)
+                partialCapture = true
+                // Skip the second click. The page already has the start cell
+                // selected; Add to Cart will queue a 1-night reservation,
+                // triggering the real booking POST that the network listener
+                // captures. The wrong_trip path then releases the hold.
+            } else {
+                log.warn(`No Available cell for last-night ${lastNight} on site ${siteNo} — slot likely partially taken`)
+                return { ok: false, reason: 'last_night_cell_missing', ctx, page }
+            }
+        } else {
+            await endCell.scrollIntoViewIfNeeded().catch(() => {})
+            await endCell.click()
+            await page.waitForTimeout(1200)
         }
-        await endCell.scrollIntoViewIfNeeded().catch(() => {})
-        await endCell.click()
-        await page.waitForTimeout(1200)
     }
     await page.screenshot({ path: screenshotPath('02-after-cell-click'), fullPage: true }).catch(() => {})
 
@@ -284,6 +303,7 @@ async function performBookingFlow(ctx, page, {
         cartState, cartShot,
         cartText: cartText.slice(0, 1500),
         observed,
+        partialCapture,
     }
 }
 
@@ -298,6 +318,7 @@ export async function tryGrabCampsite({
     endDate,            // YYYY-MM-DD (checkout)
     dryRun = true,
     accountIndex = 1,
+    captureOnPartial = false,
     log = console,
 } = {}) {
     const acct = getAccount(accountIndex)
@@ -320,7 +341,7 @@ export async function tryGrabCampsite({
         await page.screenshot({ path: screenshotPath('01-loaded'), fullPage: true }).catch(() => {})
         return await performBookingFlow(ctx, page, {
             campgroundId, siteNo, startDate, endDate,
-            dryRun, accountIndex, screenshotPath, log,
+            dryRun, accountIndex, screenshotPath, log, captureOnPartial,
         })
     } catch (err) {
         log.error(`tryGrabCampsite error: ${err.message}`)
@@ -411,12 +432,12 @@ export async function warmCampspotWindow({
         log.info(`${tag} logged-in session confirmed; warm window idling`)
     }
 
-    const hot = async ({ siteNo, startDate, endDate }) => {
+    const hot = async ({ siteNo, startDate, endDate, captureOnPartial = false }) => {
         const t0 = Date.now()
         const screenshotPath = (label) =>
             path.resolve(`${shotsDir}/${Date.now()}-cg${campgroundId}-site${siteNo}-warm-${label}.png`)
         const url = `${baseUrl}?startdate=${startDate}&enddate=${endDate}`
-        log.info(`${tag} hot: ${siteNo} ${startDate}→${endDate}`)
+        log.info(`${tag} hot: ${siteNo} ${startDate}→${endDate}${captureOnPartial ? ' (captureOnPartial=on)' : ''}`)
         // Navigate the existing page — much faster than a cold launch because
         // cookies, DNS, and HTTP/2 connections all stay warm.
         try {
@@ -429,7 +450,7 @@ export async function warmCampspotWindow({
         await handleLoginModalIfPresent(page, { log, accountIndex })
         const r = await performBookingFlow(ctx, page, {
             campgroundId, siteNo, startDate, endDate,
-            dryRun: false, accountIndex, screenshotPath, log,
+            dryRun: false, accountIndex, screenshotPath, log, captureOnPartial,
         })
         r.latencyMs = { total: Date.now() - t0 }
         log.info(`${tag} hot done in ${r.latencyMs.total}ms (state=${r.cartState ?? r.reason})`)

--- a/campspot-bot/campspot-bot.mjs
+++ b/campspot-bot/campspot-bot.mjs
@@ -2,7 +2,7 @@
 import * as dotenv from 'dotenv'
 dotenv.config()
 
-import { readFileSync } from 'node:fs'
+import { readFileSync, readdirSync, existsSync } from 'node:fs'
 import { createReadStream } from 'node:fs'
 import path from 'node:path'
 import axios from 'axios'
@@ -163,7 +163,19 @@ async function cmdRelease({ accountIndex = 1 } = {}) {
 // watch: poll continuously, notify on new openings. With --auto-grab, fires
 // CampspotCartBot on the highest-ranked new stay (sequentially — one cart at
 // a time so we don't trigger captchas).
-async function cmdWatch({ autoGrab = false, accountIndex = 1 } = {}) {
+// Auto-disabling capture-on-partial helper: returns true when capture mode
+// should fire on a partial race. Goes false the moment any capture lands in
+// .captures/, so we don't squat the user with multiple 1-night phantom holds
+// after we already have the intel we need.
+const CAPTURES_DIR = path.resolve('./campspot-bot/.captures')
+function shouldCaptureOnPartial(captureFlagOn) {
+    if (!captureFlagOn) return false
+    if (!existsSync(CAPTURES_DIR)) return true
+    const files = readdirSync(CAPTURES_DIR).filter(f => /^booking-post-.+\.json$/.test(f))
+    return files.length === 0
+}
+
+async function cmdWatch({ autoGrab = false, accountIndex = 1, captureOnPartial = false } = {}) {
     const config = loadConfig()
     const checker = new CampspotChecker({
         campgroundId: config.campgroundId,
@@ -362,12 +374,15 @@ async function cmdWatch({ autoGrab = false, accountIndex = 1 } = {}) {
                                 } catch (err) {
                                     log.warn(`recheck threw: ${err.message} — proceeding with original range`)
                                 }
+                                const fireCaptureOnPartial = shouldCaptureOnPartial(captureOnPartial)
+                                if (fireCaptureOnPartial) log.info(`captureOnPartial=on for this fire (no capture exists yet)`)
                                 log.info(`auto-grab: ${fmtStay(toFire)}`)
                                 const r = warm
                                     ? await warm.hot({
                                         siteNo: toFire.siteNo,
                                         startDate: toFire.startDate,
                                         endDate: toFire.endDate,
+                                        captureOnPartial: fireCaptureOnPartial,
                                     })
                                     : await tryGrabCampsite({
                                         campgroundId: config.campgroundId,
@@ -377,6 +392,7 @@ async function cmdWatch({ autoGrab = false, accountIndex = 1 } = {}) {
                                         endDate: toFire.endDate,
                                         dryRun: false,
                                         accountIndex,
+                                        captureOnPartial: fireCaptureOnPartial,
                                         log,
                                     })
                                 if (r.cartState === 'held') dashState.metrics.cartHolds += 1
@@ -475,14 +491,22 @@ const kv = Object.fromEntries(
             case 'release-cart':
                 await cmdRelease({ accountIndex }); break
             case 'watch':
-                await cmdWatch({ autoGrab: flags.has('--auto-grab'), accountIndex }); break
+                await cmdWatch({
+                    autoGrab: flags.has('--auto-grab'),
+                    accountIndex,
+                    captureOnPartial: flags.has('--capture-on-partial'),
+                }); break
             default:
                 console.log(`Usage:
   node campspot-bot/campspot-bot.mjs check                                  # one-shot availability scan
   node campspot-bot/campspot-bot.mjs cart --site=068 --start=YYYY-MM-DD --end=YYYY-MM-DD [--for-real] [--account=N]
                                                                             # dry-run by default; --for-real adds to cart
   node campspot-bot/campspot-bot.mjs release-cart [--account=N]             # clear holds (test cleanup)
-  node campspot-bot/campspot-bot.mjs watch [--auto-grab] [--account=N]      # poll continuously, notify; --auto-grab fires the cart bot
+  node campspot-bot/campspot-bot.mjs watch [--auto-grab] [--capture-on-partial] [--account=N]
+                                                                            # --capture-on-partial: when last-night cell collapses mid-flow, proceed
+                                                                            #   with Add to Cart anyway to harvest the booking POST (auto-disables
+                                                                            #   after the first capture lands in .captures/). wrong_trip handler
+                                                                            #   releases the resulting 1-night phantom hold.
 
 Edit campspot-bot/config.json for campgroundId / weekday filter / window.
 Re-uses the permit-bot rec.gov session — run \`node permit-bot/permit-bot.mjs login\` first.


### PR DESCRIPTION
## Summary

The booking-POST capture listener from #19 has never fired because every recent race bails at \`last_night_cell_missing\` *before* clicking Add to Cart — the very POST we want to record is the one the bail prevents.

This adds an opt-in \`--capture-on-partial\` flag. When passed, the warm window proceeds with start-cell-only Add to Cart on collapsed-range fires, just to harvest the booking POST. The existing \`wrong_trip\` handler auto-releases the resulting 1-night phantom hold within ~15s.

**Auto-disabling:** \`shouldCaptureOnPartial()\` checks \`campspot-bot/.captures/\` before every fire and returns false the moment any \`booking-post-*.json\` file lands. So even with the flag on at startup, subsequent races bail normally once we have the intel.

## What we get with one capture

The exact body shape for \`POST /api/camps/reservations/campgrounds/{id}/multi\` — minified field names included. Follow-up PR replays it via axios directly in parallel with the UI clicks, killing the 3s click-latency that's lost us the last 3 races.

## Files

- \`campspot-bot/CampspotCartBot.mjs\` — \`captureOnPartial\` param plumbed through \`performBookingFlow\` + both entry points
- \`campspot-bot/campspot-bot.mjs\` — \`--capture-on-partial\` CLI flag, \`shouldCaptureOnPartial()\` helper, watch-loop wiring, usage doc

## Test plan

- [x] \`npm test\` — 212 / 212
- [x] Bot restarted with flag; log shows \`--capture-on-partial\` in the cmdline
- [ ] Next collapsed-range race produces:
  - one new file in \`.captures/booking-post-*.json\`
  - one \`wrong_trip\` event in the dashboard
  - one cart-released log line
- [ ] After capture #1, subsequent races bail normally (no more phantom holds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)