### PR TITLE
fix(campspot-bot): 20s→30s poll + ±25% jitter to dodge WAF

### DIFF
--- a/campspot-bot/campspot-bot.mjs
+++ b/campspot-bot/campspot-bot.mjs
@@ -439,7 +439,13 @@ async function cmdWatch({ autoGrab = false, accountIndex = 1 } = {}) {
         }
         persistState()
         const elapsed = Date.now() - t0
-        const sleepMs = Math.max(0, config.pollIntervalMs - elapsed) + checker.backoffMs
+        // ±25% jitter on the base interval so we don't look like a metronome
+        // to rec.gov's WAF. 20s polling tripped repeated 429s 2026-06-24 even
+        // though it's only 3 req/min — a perfectly periodic cadence is itself
+        // a fingerprint. Jitter keeps the AVERAGE rate the same but smears
+        // the requests across a window so we don't stack on the same second.
+        const jitterMs = Math.floor((Math.random() - 0.5) * config.pollIntervalMs * 0.5)
+        const sleepMs = Math.max(0, config.pollIntervalMs - elapsed + jitterMs) + checker.backoffMs
         await new Promise(r => setTimeout(r, sleepMs))
     }
 }

--- a/campspot-bot/config.json
+++ b/campspot-bot/config.json
@@ -8,6 +8,6 @@
   "maxNights": 4,
   "minNights": 2,
   "minPeople": 6,
-  "pollIntervalMs": 20000,
+  "pollIntervalMs": 30000,
   "autoCart": false
 }


### PR DESCRIPTION
## Summary

20s polling tripped rec.gov's WAF repeatedly today: 54 errors across 1149 cycles, mostly 429s with the backoff handler escalating through 4 / 8 / 16 / 32 / 64s windows. Then ECONNRESET overnight (same WAF, just dropping connections instead of returning 429).

Two changes:

1. **Base interval 20s → 30s** in config.json. Still 2× the original 60s default, just less aggressive.
2. **±25% jitter** in the watch-loop sleep. A perfectly periodic 20s cadence is itself a fingerprint — even at 3 req/min the WAF was rate-limiting because every request stacked on the same seconds-modulo. Jitter keeps the average rate the same but smears arrivals across a ~15s window so we don't pile up on identical instants.

Jitter is applied to the elapsed-time-corrected sleep but BEFORE backoff is added, so backoff still acts as a hard floor — when 429s come in, the exponential backoff doesn't get blended with random noise.

## Test plan

- [x] \`npm test\` — 212 / 212
- [x] Bot restarted on PID 6635; log shows \`poll=30000ms\`
- [ ] Next 12h: errors trend back down (target: < 5 / 1000 cycles vs current 54 / 1149)

🤖 Generated with [Claude Code](https://claude.com/claude-code)