### PR TITLE
fix(campspot-bot): verifier regex + keep ≥minNights wrong_trip holds

### DIFF
--- a/campspot-bot/CampspotCartBot.mjs
+++ b/campspot-bot/CampspotCartBot.mjs
@@ -146,9 +146,14 @@ async function verifyCartHold(ctx, { siteNo, startDate, endDate, screenshotPath 
         cartText = await cartPage.evaluate(() => document.body.innerText)
 
         // Pull the literal check-in / check-out lines so we can report what we
-        // actually got, not just true/false. Pattern: "Check-In Date: Thu Jun 25, 2026".
-        const ciMatch = cartText.match(/Check-In Date:\s*\w+\s+(\w+)\s+(\d+),\s+(\d{4})/i)
-        const coMatch = cartText.match(/Check-Out Date:\s*\w+\s+(\w+)\s+(\d+),\s+(\d{4})/i)
+        // actually got, not just true/false. rec.gov uses TWO different labels
+        // depending on the view: "Check-In Date: Thu Jun 25, 2026" (full) and
+        // "Check-In: Thu Jul 23, 2026" (compact). The 2026-06-25 cascade lost
+        // a real hold because the regex only matched the full form and the
+        // compact-form cart fell through to `has_items_but_not_target` (no
+        // auto-release, no Discord/ntfy alert, hold expired silently).
+        const ciMatch = cartText.match(/Check-?\s*In(?:\s+Date)?:\s*\w+\s+(\w+)\s+(\d+),\s+(\d{4})/i)
+        const coMatch = cartText.match(/Check-?\s*Out(?:\s+Date)?:\s*\w+\s+(\w+)\s+(\d+),\s+(\d{4})/i)
         if (ciMatch) observed.checkIn = `${ciMatch[1]} ${ciMatch[2]}, ${ciMatch[3]}`
         if (coMatch) observed.checkOut = `${coMatch[1]} ${coMatch[2]}, ${coMatch[3]}`
 
@@ -176,6 +181,27 @@ async function verifyCartHold(ctx, { siteNo, startDate, endDate, screenshotPath 
 //
 // Returns the same shape as the public entry points so they can pass it
 // straight through.
+// Count actual nights in a `wrong_trip` observation (e.g. "Thu Jul 23, 2026"
+// → "Sat Jul 25, 2026" = 2 nights). Returns null if either side fails to
+// parse. Used to decide whether a partial hold is still worth keeping
+// (≥ minNights) or should be auto-released.
+function observedNights(checkInStr, checkOutStr) {
+    if (!checkInStr || !checkOutStr) return null
+    const monthLookup = { Jan: 0, Feb: 1, Mar: 2, Apr: 3, May: 4, Jun: 5, Jul: 6, Aug: 7, Sep: 8, Oct: 9, Nov: 10, Dec: 11 }
+    const parse = (s) => {
+        // "Jul 23, 2026"
+        const m = s.match(/^(\w+)\s+(\d+),\s+(\d{4})$/)
+        if (!m) return null
+        const month = monthLookup[m[1].slice(0, 3)]
+        if (month == null) return null
+        return Date.UTC(Number(m[3]), month, Number(m[2]))
+    }
+    const ci = parse(checkInStr)
+    const co = parse(checkOutStr)
+    if (ci == null || co == null) return null
+    return Math.round((co - ci) / 86400000)
+}
+
 async function performBookingFlow(ctx, page, {
     campgroundId,
     siteNo,
@@ -183,6 +209,10 @@ async function performBookingFlow(ctx, page, {
     endDate,
     dryRun = false,
     accountIndex = 1,
+    // minNights: when a wrong_trip lands a partial hold, only auto-release if
+    // the observed range is BELOW this threshold. A 4-night request that
+    // landed a 2-night hold is still worth keeping if minNights=2.
+    minNights = 1,
     screenshotPath,
     log = console,
 }) {
@@ -267,14 +297,24 @@ async function performBookingFlow(ctx, page, {
     })
     log.info(`Cart state: ${cartState} (observed checkIn=${observed.checkIn}, checkOut=${observed.checkOut})`)
 
-    // Step 6: auto-release wrong_trip holds so they don't squat for 15 min.
+    // Step 6: wrong_trip handling. Auto-release ONLY if the partial hold is
+    // below minNights — anything ≥ minNights is still worth keeping and
+    // letting the user decide. Tonight's Site 100 cascade lost a perfectly
+    // good 2-night hold because we auto-released by default.
+    const partialNights = cartState === 'wrong_trip' ? observedNights(observed.checkIn, observed.checkOut) : null
+    let autoReleased = false
     if (cartState === 'wrong_trip') {
-        log.warn(`wrong_trip detected — releasing hold (wanted ${startDate}→${endDate}, got checkOut=${observed.checkOut})`)
-        try {
-            const r = await releaseCampspotCart({ accountIndex, log })
-            log.info(`released stale wrong_trip hold: removed=${r.removed} state=${r.state}`)
-        } catch (err) {
-            log.warn(`auto-release after wrong_trip failed: ${err.message}`)
+        if (partialNights != null && partialNights >= minNights) {
+            log.warn(`wrong_trip but observed ${partialNights}n ≥ minNights=${minNights} — KEEPING hold for user to decide`)
+        } else {
+            log.warn(`wrong_trip with observed=${partialNights}n < minNights=${minNights} — releasing (wanted ${startDate}→${endDate}, got ${observed.checkIn}→${observed.checkOut})`)
+            try {
+                const r = await releaseCampspotCart({ accountIndex, log })
+                log.info(`released stale wrong_trip hold: removed=${r.removed} state=${r.state}`)
+                autoReleased = true
+            } catch (err) {
+                log.warn(`auto-release after wrong_trip failed: ${err.message}`)
+            }
         }
     }
 
@@ -284,6 +324,8 @@ async function performBookingFlow(ctx, page, {
         cartState, cartShot,
         cartText: cartText.slice(0, 1500),
         observed,
+        partialNights,
+        autoReleased,
     }
 }
 
@@ -298,6 +340,7 @@ export async function tryGrabCampsite({
     endDate,            // YYYY-MM-DD (checkout)
     dryRun = true,
     accountIndex = 1,
+    minNights = 1,
     log = console,
 } = {}) {
     const acct = getAccount(accountIndex)
@@ -320,7 +363,7 @@ export async function tryGrabCampsite({
         await page.screenshot({ path: screenshotPath('01-loaded'), fullPage: true }).catch(() => {})
         return await performBookingFlow(ctx, page, {
             campgroundId, siteNo, startDate, endDate,
-            dryRun, accountIndex, screenshotPath, log,
+            dryRun, accountIndex, minNights, screenshotPath, log,
         })
     } catch (err) {
         log.error(`tryGrabCampsite error: ${err.message}`)
@@ -426,7 +469,7 @@ export async function warmCampspotWindow({
     const isClosedContextError = (err) =>
         /closed|disconnected|crashed|browser has been closed/i.test(err?.message || '')
 
-    const hot = async ({ siteNo, startDate, endDate }) => {
+    const hot = async ({ siteNo, startDate, endDate, minNights = 1 }) => {
         // Pre-flight: if the previous fire (or the 11-hour idle gap from
         // 2026-06-24) killed the context, recreate it BEFORE we burn time
         // navigating to a dead tab.
@@ -454,7 +497,7 @@ export async function warmCampspotWindow({
             await handleLoginModalIfPresent(page, { log, accountIndex })
             const r = await performBookingFlow(ctx, page, {
                 campgroundId, siteNo, startDate, endDate,
-                dryRun: false, accountIndex, screenshotPath, log,
+                dryRun: false, accountIndex, minNights, screenshotPath, log,
             })
             r.latencyMs = { total: Date.now() - t0 }
             log.info(`${tag} hot done in ${r.latencyMs.total}ms (state=${r.cartState ?? r.reason})`)

--- a/campspot-bot/__tests__/observedNights.test.mjs
+++ b/campspot-bot/__tests__/observedNights.test.mjs
@@ -1,0 +1,71 @@
+// observedNights() isn't exported (intentionally module-local), but its
+// behaviour is the load-bearing piece of the wrong_trip / auto-release
+// decision. We exercise it indirectly via the date-format regex's expected
+// pairs to lock in the parsing contract.
+
+// Equivalent inline version for test purposes — kept in sync with
+// CampspotCartBot.mjs's local observedNights().
+const monthLookup = { Jan: 0, Feb: 1, Mar: 2, Apr: 3, May: 4, Jun: 5, Jul: 6, Aug: 7, Sep: 8, Oct: 9, Nov: 10, Dec: 11 }
+function observedNights(ci, co) {
+    if (!ci || !co) return null
+    const parse = (s) => {
+        const m = s.match(/^(\w+)\s+(\d+),\s+(\d{4})$/)
+        if (!m) return null
+        const month = monthLookup[m[1].slice(0, 3)]
+        if (month == null) return null
+        return Date.UTC(Number(m[3]), month, Number(m[2]))
+    }
+    const a = parse(ci), b = parse(co)
+    if (a == null || b == null) return null
+    return Math.round((b - a) / 86400000)
+}
+
+describe('observedNights', () => {
+    test('2-night Jul 23 → Jul 25', () => {
+        // This is THE case from 2026-06-25 — Site 100, asked 4n, got 2n.
+        // partialNights=2 >= minNights=2 → KEEP the hold.
+        expect(observedNights('Jul 23, 2026', 'Jul 25, 2026')).toBe(2)
+    })
+
+    test('1-night next-day stay', () => {
+        expect(observedNights('Sep 13, 2026', 'Sep 14, 2026')).toBe(1)
+    })
+
+    test('4-night across a month boundary', () => {
+        expect(observedNights('Jun 29, 2026', 'Jul 3, 2026')).toBe(4)
+    })
+
+    test('returns null on malformed input', () => {
+        expect(observedNights(null, 'Sep 14, 2026')).toBeNull()
+        expect(observedNights('not-a-date', 'Sep 14, 2026')).toBeNull()
+        expect(observedNights('Sep 13, 2026', 'XYZ 14, 2026')).toBeNull()
+    })
+
+    test('handles year boundary', () => {
+        expect(observedNights('Dec 30, 2026', 'Jan 2, 2027')).toBe(3)
+    })
+})
+
+describe('Check-In/Out regex tolerates both rec.gov formats', () => {
+    // The 2026-06-25 cart used "Check-In: Thu Jul 23, 2026" (no Date word).
+    // The 2026-06-22 cart used "Check-In Date: Sun Sep 13, 2026" (with Date).
+    const ciRegex = /Check-?\s*In(?:\s+Date)?:\s*\w+\s+(\w+)\s+(\d+),\s+(\d{4})/i
+    const coRegex = /Check-?\s*Out(?:\s+Date)?:\s*\w+\s+(\w+)\s+(\d+),\s+(\d{4})/i
+
+    test('matches "Check-In Date:" form (legacy)', () => {
+        const m = 'Check-In Date: Sun Sep 13, 2026'.match(ciRegex)
+        expect(m).not.toBeNull()
+        expect(`${m[1]} ${m[2]}, ${m[3]}`).toBe('Sep 13, 2026')
+    })
+
+    test('matches "Check-In:" form (compact, the one that broke us)', () => {
+        const m = 'Check-In: Thu Jul 23, 2026'.match(ciRegex)
+        expect(m).not.toBeNull()
+        expect(`${m[1]} ${m[2]}, ${m[3]}`).toBe('Jul 23, 2026')
+    })
+
+    test('Check-Out variants both match', () => {
+        expect('Check-Out Date: Fri Jun 26, 2026'.match(coRegex)).not.toBeNull()
+        expect('Check-Out: Sat Jul 25, 2026'.match(coRegex)).not.toBeNull()
+    })
+})

--- a/campspot-bot/campspot-bot.mjs
+++ b/campspot-bot/campspot-bot.mjs
@@ -368,6 +368,7 @@ async function cmdWatch({ autoGrab = false, accountIndex = 1 } = {}) {
                                         siteNo: toFire.siteNo,
                                         startDate: toFire.startDate,
                                         endDate: toFire.endDate,
+                                        minNights: config.minNights,
                                     })
                                     : await tryGrabCampsite({
                                         campgroundId: config.campgroundId,
@@ -377,6 +378,7 @@ async function cmdWatch({ autoGrab = false, accountIndex = 1 } = {}) {
                                         endDate: toFire.endDate,
                                         dryRun: false,
                                         accountIndex,
+                                        minNights: config.minNights,
                                         log,
                                     })
                                 if (r.cartState === 'held') dashState.metrics.cartHolds += 1
@@ -394,7 +396,9 @@ async function cmdWatch({ autoGrab = false, accountIndex = 1 } = {}) {
                                 const status = r.cartState === 'held'
                                     ? '✅ **CART HOLD CONFIRMED** — go check out!'
                                     : r.cartState === 'wrong_trip'
-                                        ? `⚠️ **WRONG TRIP** — rec.gov gave us check-out ${r.observed?.checkOut} (wanted ${toFire.endDate}). Hold auto-released.`
+                                        ? (r.autoReleased
+                                            ? `⚠️ **WRONG TRIP** — rec.gov gave us ${r.observed?.checkIn ?? '?'} → ${r.observed?.checkOut ?? '?'} (wanted ${toFire.startDate}→${toFire.endDate}, ${r.partialNights ?? '?'}n < minNights). Auto-released.`
+                                            : `🟡 **PARTIAL HOLD** — ${r.partialNights ?? '?'}n hold (${r.observed?.checkIn ?? '?'} → ${r.observed?.checkOut ?? '?'}), wanted ${toFire.nights}n. Decide before 15-min timer expires.`)
                                         : `⚠️ auto-grab finished — cart state: ${r.cartState ?? r.reason ?? 'unknown'}`
                                 await discordPush([
                                     status,
@@ -411,6 +415,18 @@ async function cmdWatch({ autoGrab = false, accountIndex = 1 } = {}) {
                                             click: 'https://www.recreation.gov/cart',
                                             priority: 'max',
                                             tags: 'tent,white_check_mark,rotating_light',
+                                        },
+                                    )
+                                } else if (r.cartState === 'wrong_trip' && !r.autoReleased) {
+                                    // Partial hold that we KEPT because it meets minNights —
+                                    // user should check it. ntfy with same urgency as held.
+                                    await pushNtfy(
+                                        `PARTIAL: ${config.campgroundName} site ${toFire.siteNo}`,
+                                        `Got ${r.partialNights ?? '?'}n (${r.observed?.checkIn ?? '?'} → ${r.observed?.checkOut ?? '?'}) — wanted ${toFire.nights}n. Check cart NOW, 15-min timer running.`,
+                                        {
+                                            click: 'https://www.recreation.gov/cart',
+                                            priority: 'max',
+                                            tags: 'tent,warning,rotating_light',
                                         },
                                     )
                                 }


### PR DESCRIPTION
## Summary

Tonight at 07:30 UTC the bot fired on Site 100 (a 3-nighter) and rec.gov **actually gave us a 2-night hold** — exactly the kind of partial we'd happily camp. But two bugs working together silently expired it within 15 minutes:

1. **Verifier regex mismatch.** rec.gov uses two cart label formats — `Check-In Date: …` (long) and `Check-In: …` (compact). My regex only matched the long form. Site 100's cart was compact, so the verifier never extracted check-in/out, never hit the wrong_trip branch, fell through to `has_items_but_not_target`. No auto-release, no Discord, no ntfy.
2. **Auto-release was unconditional.** Even when wrong_trip *did* fire correctly, the bot auto-released any partial. A 4-night request that landed a 2-night hold (meeting minNights=2) would lose a perfectly good campsite to defensive cleanup.

## Fixes

- Verifier regex now accepts both forms: `Check-?\s*In(?:\s+Date)?:` and same for Out.
- New module-local `observedNights(checkIn, checkOut)` helper.
- **Auto-release rule: only when observed nights < minNights.** ≥ minNights stays in cart, user gets a max-priority ntfy push and a Discord card with the actual observed range.
- `minNights` threads from config.json → watch loop → `tryGrabCampsite` / `warm.hot` → `performBookingFlow`.
- Cold path (`tryGrabCampsite`) and warm path (`warm.hot`) both accept the new param.

## Discord copy now distinguishes three states

- `held` — full match, "✅ CART HOLD CONFIRMED — go check out!"
- `wrong_trip` with auto-release — "⚠️ WRONG TRIP — got Xn < minNights. Auto-released."
- `wrong_trip` kept — "🟡 PARTIAL HOLD — Xn (Jul 23 → Jul 25), wanted 4n. Decide before 15-min timer."

ntfy fires max-priority on both `held` AND kept-partial. Auto-released fires Discord only.

## Test plan

- [x] `npm test` — 220 / 220 (8 new)
- [x] Bot restarted with the fix in memory; warm window logged in cleanly
- [ ] Next wrong_trip fire: log shows `observed=Xn ≥/< minNights` and the right branch wins

🤖 Generated with [Claude Code](https://claude.com/claude-code)