### PR TITLE
chore(campspot-bot): rangeStartDate → 2026-07-16

### DIFF
--- a/campspot-bot/config.json
+++ b/campspot-bot/config.json
@@ -2,7 +2,7 @@
   "campgroundId": "232447",
   "campgroundName": "Upper Pines Campground",
   "park": "Yosemite",
-  "rangeStartDate": "2026-06-22",
+  "rangeStartDate": "2026-07-16",
   "rangeEndDate": "2026-09-30",
   "targetWeekdays": ["Thu", "Fri", "Sat", "Sun"],
   "maxNights": 4,


### PR DESCRIPTION
Skip the Jul 2-5 weekend window (user is no longer interested in those dates) and focus on Thu-Sun stays starting Jul 16 or later.

Window: 2026-07-16 → 2026-09-30. First qualifying Thu-Sun stay: Jul 16-20 (4 nights, the longest Thu→Mon allowed under maxNights=4).

Running bot already restarted with this config; the PR is to persist the change in main so future restarts inherit it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)