### PR TITLE
feat(campspot-bot): dynamic leadDays — sliding 'today + N days' floor

### DIFF
--- a/campspot-bot/CampspotChecker.mjs
+++ b/campspot-bot/CampspotChecker.mjs
@@ -38,15 +38,38 @@ function mergeMonths(target, src) {
     }
 }
 
+// Today's date in PT (America/Los_Angeles), formatted YYYY-MM-DD. The lead-
+// time window is anchored to PT because the user lives in PT, rec.gov dates
+// are presented in PT, and check-in is end-of-day local. Using local Date
+// would drift by a day for users in different timezones; Intl.DateTimeFormat
+// pins it.
+const PT_YMD = new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'America/Los_Angeles',
+    year: 'numeric', month: '2-digit', day: '2-digit',
+})
+function todayPT() {
+    return PT_YMD.format(new Date())
+}
+function addDaysPT(yyyymmdd, n) {
+    const ms = Date.parse(`${yyyymmdd}T00:00:00Z`) + n * 86400000
+    return new Date(ms).toISOString().slice(0, 10)
+}
+
 export default class CampspotChecker {
     constructor({
         campgroundId,
-        rangeStartDate, // YYYY-MM-DD inclusive
+        rangeStartDate, // YYYY-MM-DD inclusive (absolute floor)
         rangeEndDate,   // YYYY-MM-DD inclusive
         targetWeekdays = ['Thu', 'Fri', 'Sat', 'Sun'],
         maxNights = 4,
         minNights = 1,
         minPeople = 0,
+        // leadDays: when set, the effective range start is max(rangeStartDate,
+        // today + leadDays) — recomputed on every diff() so the window slides
+        // forward as days pass. Use this when the user needs decision-time
+        // lead time before a trip (e.g. "always 15 days out so the friend
+        // group can plan"). Set 0 / undefined for absolute-only mode.
+        leadDays = 0,
         log,
     }) {
         if (!campgroundId) throw new Error('CampspotChecker: campgroundId required')
@@ -58,6 +81,7 @@ export default class CampspotChecker {
         this.maxNights = maxNights
         this.minNights = minNights
         this.minPeople = minPeople
+        this.leadDays = Number.isFinite(leadDays) ? leadDays : 0
         this.log = log || console
         this.backoffMs = 0
         this.lastErrorReason = null
@@ -65,8 +89,19 @@ export default class CampspotChecker {
         this.lastSeenStays = new Map()
     }
 
+    // Recompute the effective start date — slides forward each PT day when
+    // leadDays > 0. Returns whichever floor is later: the static
+    // rangeStartDate or today + leadDays.
+    effectiveStartDate() {
+        if (this.leadDays > 0) {
+            const dynamicFloor = addDaysPT(todayPT(), this.leadDays)
+            return dynamicFloor > this.rangeStartDate ? dynamicFloor : this.rangeStartDate
+        }
+        return this.rangeStartDate
+    }
+
     monthStarts() {
-        return monthStartsFor(this.rangeStartDate, this.rangeEndDate)
+        return monthStartsFor(this.effectiveStartDate(), this.rangeEndDate)
     }
 
     async pollOnce() {
@@ -88,9 +123,10 @@ export default class CampspotChecker {
     // subset never seen before (dedup keyed by campsiteId|start|end), so
     // callers can notify exactly once per new opening.
     diff(campsitesPayload) {
+        const effStart = this.effectiveStartDate()
         const stays = findAllStays({
             campsitesPayload,
-            rangeStartDate: this.rangeStartDate,
+            rangeStartDate: effStart,
             rangeEndDate: this.rangeEndDate,
             targetWeekdays: this.targetWeekdays,
             maxNights: this.maxNights,
@@ -115,7 +151,7 @@ export default class CampspotChecker {
         return {
             snapshot: {
                 fetchedAt: new Date().toISOString(),
-                rangeStartDate: this.rangeStartDate,
+                rangeStartDate: effStart,
                 rangeEndDate: this.rangeEndDate,
                 stays: ranked,
                 campsiteCount: Object.keys(campsitesPayload || {}).length,

--- a/campspot-bot/__tests__/leadDays.test.mjs
+++ b/campspot-bot/__tests__/leadDays.test.mjs
@@ -1,0 +1,43 @@
+import CampspotChecker from '../CampspotChecker.mjs'
+
+const baseConfig = {
+    campgroundId: '232447',
+    rangeStartDate: '2026-06-22',
+    rangeEndDate: '2026-09-30',
+    targetWeekdays: ['Thu', 'Fri', 'Sat', 'Sun'],
+    maxNights: 4,
+    minNights: 1,
+    log: { info: () => {}, warn: () => {}, error: () => {} },
+}
+
+describe('CampspotChecker.effectiveStartDate', () => {
+    test('returns static rangeStartDate when leadDays is 0', () => {
+        const c = new CampspotChecker({ ...baseConfig, leadDays: 0 })
+        expect(c.effectiveStartDate()).toBe('2026-06-22')
+    })
+
+    test('returns static rangeStartDate when leadDays is undefined', () => {
+        const c = new CampspotChecker({ ...baseConfig })
+        expect(c.effectiveStartDate()).toBe('2026-06-22')
+    })
+
+    test('returns today + leadDays when that is later than rangeStartDate', () => {
+        const c = new CampspotChecker({ ...baseConfig, leadDays: 15 })
+        const out = c.effectiveStartDate()
+        // Today + 15 days in PT. Computing the same way as the helper would
+        // would be circular; instead verify the shape and that it's later than
+        // the static floor.
+        expect(out).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+        expect(out > '2026-06-22').toBe(true)
+    })
+
+    test('falls back to static rangeStartDate when today + leadDays is earlier', () => {
+        // Static floor in the far future + small leadDays → static wins.
+        const c = new CampspotChecker({
+            ...baseConfig,
+            rangeStartDate: '2099-01-01',
+            leadDays: 1,
+        })
+        expect(c.effectiveStartDate()).toBe('2099-01-01')
+    })
+})

--- a/campspot-bot/campspot-bot.mjs
+++ b/campspot-bot/campspot-bot.mjs
@@ -104,9 +104,10 @@ async function cmdCheck() {
         maxNights: config.maxNights,
         minNights: config.minNights,
         minPeople: config.minPeople,
+        leadDays: config.leadDays,
         log,
     })
-    log.info(`check: cg=${config.campgroundId} window=${config.rangeStartDate}..${config.rangeEndDate} weekdays=${config.targetWeekdays.join(',')} nights=${config.minNights}-${config.maxNights} minPeople=${config.minPeople}`)
+    log.info(`check: cg=${config.campgroundId} window=${checker.effectiveStartDate()}..${config.rangeEndDate} (leadDays=${config.leadDays || 0}) weekdays=${config.targetWeekdays.join(',')} nights=${config.minNights}-${config.maxNights} minPeople=${config.minPeople}`)
     const payload = await checker.pollOnce()
     const { snapshot } = checker.diff(payload)
     log.info(`Scanned ${snapshot.campsiteCount} campsites, found ${snapshot.stays.length} qualifying stays.`)
@@ -173,9 +174,10 @@ async function cmdWatch({ autoGrab = false, accountIndex = 1 } = {}) {
         maxNights: config.maxNights,
         minNights: config.minNights,
         minPeople: config.minPeople,
+        leadDays: config.leadDays,
         log,
     })
-    log.info(`watch: cg=${config.campgroundId} window=${config.rangeStartDate}..${config.rangeEndDate} ` +
+    log.info(`watch: cg=${config.campgroundId} window=${checker.effectiveStartDate()}..${config.rangeEndDate} (leadDays=${config.leadDays || 0}) ` +
         `weekdays=${config.targetWeekdays.join(',')} nights=${config.minNights}-${config.maxNights} ` +
         `minPeople=${config.minPeople} poll=${config.pollIntervalMs}ms autoGrab=${autoGrab}`)
 

--- a/campspot-bot/config.json
+++ b/campspot-bot/config.json
@@ -2,6 +2,7 @@
   "campgroundId": "232447",
   "campgroundName": "Upper Pines Campground",
   "park": "Yosemite",
+  "leadDays": 15,
   "rangeStartDate": "2026-06-22",
   "rangeEndDate": "2026-09-30",
   "targetWeekdays": ["Thu", "Fri", "Sat", "Sun"],


### PR DESCRIPTION
Friends need decision time before a trip — last-minute bookings don't work. Replaces the hard-coded `rangeStartDate` with a dynamic floor that's `max(rangeStartDate, today + leadDays)`, recomputed on every diff() so the window slides forward each day automatically.

## Config

```json
"leadDays": 15
```

- Today (2026-06-25 PT) → effective window `2026-07-10 → 2026-09-30`
- Tomorrow → auto-advances to `2026-07-11 → 2026-09-30`
- And so on each PT midnight

## Notes

- **PT-anchored** via `Intl.DateTimeFormat('America/Los_Angeles')` — won't drift by a day at PT midnight when the server is UTC.
- Static `rangeStartDate` kept as an absolute floor (in case the user ever sets it to something far future).
- `leadDays` defaults to 0, so existing configs without it behave exactly as before.
- snapshot.rangeStartDate now reports the effective value so dashboards / Discord see the actual window.

## Test plan

- [x] `npm test` — 216 / 216 (4 new tests on `effectiveStartDate`)
- [x] Bot restarted: log shows `window=2026-07-10..2026-09-30 (leadDays=15)`
- [ ] Tomorrow's log should auto-show `window=2026-07-11..2026-09-30` — confirm at the next monitor tick

🤖 Generated with [Claude Code](https://claude.com/claude-code)