### PR TITLE
fix(dashboard): show effective leadDays-filtered window

### DIFF
--- a/campspot-bot/__tests__/windowDisplay.test.mjs
+++ b/campspot-bot/__tests__/windowDisplay.test.mjs
@@ -1,0 +1,24 @@
+import { windowDisplay } from '../windowDisplay.mjs'
+
+describe('windowDisplay', () => {
+    test('returns plain range when leadDays is 0', () => {
+        const out = windowDisplay('2026-06-22', '2026-09-30', 0, '2026-06-22')
+        expect(out).toBe('2026-06-22 → 2026-09-30')
+    })
+
+    test('returns plain range when leadDays is undefined', () => {
+        const out = windowDisplay('2026-06-22', '2026-09-30', undefined, '2026-06-22')
+        expect(out).toBe('2026-06-22 → 2026-09-30')
+    })
+
+    test('returns plain range when effective start equals static start', () => {
+        // Happens when static rangeStartDate is already later than today+leadDays.
+        const out = windowDisplay('2099-01-01', '2099-12-31', 15, '2099-01-01')
+        expect(out).toBe('2099-01-01 → 2099-12-31')
+    })
+
+    test('annotates with effective floor + leadDays when lead pushes start forward', () => {
+        const out = windowDisplay('2026-06-22', '2026-09-30', 15, '2026-07-11')
+        expect(out).toBe('2026-06-22 → 2026-09-30 (effective from 2026-07-11, leadDays=15)')
+    })
+})

--- a/campspot-bot/campspot-bot.mjs
+++ b/campspot-bot/campspot-bot.mjs
@@ -10,6 +10,7 @@ import FormData from 'form-data'
 
 import CampspotChecker from './CampspotChecker.mjs'
 import { tryGrabCampsite, releaseCampspotCart, warmCampspotWindow } from './CampspotCartBot.mjs'
+import { windowDisplay } from './windowDisplay.mjs'
 import { httpsAgent } from '../permit-bot/dnsBypass.mjs'
 import { writeBotState, appendEvent } from '../dashboard/botState.mjs'
 
@@ -198,7 +199,7 @@ async function cmdWatch({ autoGrab = false, accountIndex = 1 } = {}) {
         config: {
             campgroundId: config.campgroundId,
             campgroundName: config.campgroundName,
-            window: `${config.rangeStartDate} → ${config.rangeEndDate}`,
+            window: windowDisplay(config.rangeStartDate, config.rangeEndDate, config.leadDays, checker.effectiveStartDate()),
             weekdays: config.targetWeekdays,
             nights: `${config.minNights}-${config.maxNights}`,
             minPeople: config.minPeople,
@@ -220,6 +221,11 @@ async function cmdWatch({ autoGrab = false, accountIndex = 1 } = {}) {
     const persistState = () => {
         dashState.lastHeartbeat = new Date().toISOString()
         dashState.metrics.backoffMs = checker.backoffMs
+        // Recompute on every write so the effective floor slides forward as PT
+        // days roll over (leadDays mode). Cheap; no I/O.
+        dashState.config.window = windowDisplay(
+            config.rangeStartDate, config.rangeEndDate, config.leadDays, checker.effectiveStartDate(),
+        )
         try { writeBotState(STATE_FILE, dashState) } catch (err) {
             log.warn(`state write failed: ${err.message}`)
         }
@@ -261,7 +267,7 @@ async function cmdWatch({ autoGrab = false, accountIndex = 1 } = {}) {
     await discordPush([
         '🟢 **campspot-bot watch started**',
         `**Campground:** ${config.campgroundName} (${config.campgroundId})`,
-        `**Window:** ${config.rangeStartDate} → ${config.rangeEndDate}`,
+        `**Window:** ${windowDisplay(config.rangeStartDate, config.rangeEndDate, config.leadDays, checker.effectiveStartDate())}`,
         `**Weekdays:** ${config.targetWeekdays.join(', ')} · **Nights:** ${config.minNights}–${config.maxNights}`,
         `**Min capacity:** ${config.minPeople || 'any'} people`,
         `**Warm window:** ${warm ? (warm.loggedIn ? 'on (logged in)' : 'on (NOT logged in — run permit-bot login)') : 'off'}`,

--- a/campspot-bot/windowDisplay.mjs
+++ b/campspot-bot/windowDisplay.mjs
@@ -1,0 +1,9 @@
+// Operator-facing window string for the dashboard + Discord startup ping.
+// When leadDays > 0, the effective floor (today + leadDays) slides forward
+// each PT day, so callers should recompute this on every cycle if they want
+// the dashboard to reflect today's floor.
+export function windowDisplay(rangeStartDate, rangeEndDate, leadDays, effectiveStartDate) {
+    const base = `${rangeStartDate} → ${rangeEndDate}`
+    if (!leadDays || effectiveStartDate === rangeStartDate) return base
+    return `${base} (effective from ${effectiveStartDate}, leadDays=${leadDays})`
+}


### PR DESCRIPTION
## Summary
- Dashboard 'Window' row was set once at startup to the *static* `rangeStartDate → rangeEndDate`, so even with `leadDays: 15` filtering openings to today+15, the dashboard kept showing `2026-06-22 → 2026-09-30`. Misleading for an operator trying to confirm the lead-time filter is active.
- Now displays `2026-06-22 → 2026-09-30 (effective from 2026-07-11, leadDays=15)` when `leadDays > 0`; falls back to the plain range otherwise.
- Recomputed on every `persistState()` so the effective floor slides forward as PT days roll over.
- Discord startup ping uses the same string.

Helper extracted to `campspot-bot/windowDisplay.mjs` so it can be unit-tested without dragging the CLI dispatcher into the test process.

## Test plan
- [x] `npm test` — 228 passing, including 4 new `windowDisplay` cases (no leadDays, undefined leadDays, effective == static, effective > static)
- [ ] Restart the live bot and confirm the dashboard 'Window' row shows the annotated form

🤖 Generated with [Claude Code](https://claude.com/claude-code)