### PR TITLE
feat(dashboard): emit poll_recovered after backoff clears

### DIFF
--- a/campspot-bot/campspot-bot.mjs
+++ b/campspot-bot/campspot-bot.mjs
@@ -11,7 +11,7 @@ import FormData from 'form-data'
 import CampspotChecker from './CampspotChecker.mjs'
 import { tryGrabCampsite, releaseCampspotCart, warmCampspotWindow } from './CampspotCartBot.mjs'
 import { httpsAgent } from '../permit-bot/dnsBypass.mjs'
-import { writeBotState, appendEvent } from '../dashboard/botState.mjs'
+import { writeBotState, appendEvent, resetBackoffWithRecovery } from '../dashboard/botState.mjs'
 
 const STATE_FILE = path.resolve('./campspot-bot/state/status.json')
 
@@ -274,7 +274,8 @@ async function cmdWatch({ autoGrab = false, accountIndex = 1 } = {}) {
         try {
             const payload = await checker.pollOnce()
             const { snapshot, newStays } = checker.diff(payload)
-            checker.resetBackoff()
+            resetBackoffWithRecovery(checker, ({ priorBackoffMs }) =>
+                appendEvent(dashState, { type: 'poll_recovered', priorBackoffMs }))
             log.info(`cycle ${cycle}: ${snapshot.stays.length} stays (${newStays.length} new)`)
 
             dashState.metrics.cycles = cycle

--- a/dashboard/__tests__/botState.test.mjs
+++ b/dashboard/__tests__/botState.test.mjs
@@ -1,0 +1,83 @@
+// Tests for the bot-state helpers shared by campspot-bot and permit-bot.
+//
+// The interesting one here is resetBackoffWithRecovery — it bundles
+// "clear the checker's backoff" with "publish a recovery event" so a future
+// caller can't accidentally do one without the other. That invariant is the
+// reason the helper exists; these tests pin it down.
+
+import { jest } from '@jest/globals'
+import { appendEvent, resetBackoffWithRecovery } from '../botState.mjs'
+
+function fakeChecker(initialBackoffMs = 0) {
+    return {
+        backoffMs: initialBackoffMs,
+        resetBackoffCalls: 0,
+        resetBackoff() {
+            this.resetBackoffCalls += 1
+            this.backoffMs = 0
+        },
+    }
+}
+
+describe('resetBackoffWithRecovery', () => {
+    test('emits recovery with the prior backoff when backoff was non-zero', () => {
+        const checker = fakeChecker(4000)
+        const emit = jest.fn()
+
+        resetBackoffWithRecovery(checker, emit)
+
+        expect(emit).toHaveBeenCalledTimes(1)
+        expect(emit).toHaveBeenCalledWith({ priorBackoffMs: 4000 })
+        expect(checker.backoffMs).toBe(0)
+        expect(checker.resetBackoffCalls).toBe(1)
+    })
+
+    test('does not emit when checker had no pending backoff', () => {
+        const checker = fakeChecker(0)
+        const emit = jest.fn()
+
+        resetBackoffWithRecovery(checker, emit)
+
+        expect(emit).not.toHaveBeenCalled()
+        // Reset still runs so the contract is "always clear, sometimes emit":
+        // callers can rely on backoffMs being 0 afterward regardless of input.
+        expect(checker.resetBackoffCalls).toBe(1)
+        expect(checker.backoffMs).toBe(0)
+    })
+
+    test('captures backoff before reset, so emit sees the prior value not 0', () => {
+        // Regression guard: if we ever flipped the order to reset-then-read,
+        // emit would always see 0 and the recovery event would silently lie.
+        const checker = fakeChecker(2500)
+        let observedDuringEmit = null
+        resetBackoffWithRecovery(checker, ({ priorBackoffMs }) => {
+            observedDuringEmit = { priorBackoffMs, currentBackoffMs: checker.backoffMs }
+        })
+        expect(observedDuringEmit).toEqual({ priorBackoffMs: 2500, currentBackoffMs: 0 })
+    })
+
+    test('integrates with appendEvent: produces a well-formed poll_recovered row', () => {
+        const checker = fakeChecker(8000)
+        const dashState = { recentEvents: [] }
+
+        resetBackoffWithRecovery(checker, ({ priorBackoffMs }) =>
+            appendEvent(dashState, { type: 'poll_recovered', priorBackoffMs }))
+
+        expect(dashState.recentEvents).toHaveLength(1)
+        const evt = dashState.recentEvents[0]
+        expect(evt.type).toBe('poll_recovered')
+        expect(evt.priorBackoffMs).toBe(8000)
+        expect(evt.ts).toMatch(/^\d{4}-\d{2}-\d{2}T/)
+    })
+
+    test('emit can throw without leaving backoff stuck — reset already happened', () => {
+        // If a downstream emitter (Discord webhook, session.write) throws,
+        // we still want backoff cleared so the bot can keep polling. The
+        // reset runs before emit, so this should propagate cleanly.
+        const checker = fakeChecker(4000)
+        expect(() => {
+            resetBackoffWithRecovery(checker, () => { throw new Error('emit boom') })
+        }).toThrow('emit boom')
+        expect(checker.backoffMs).toBe(0)
+    })
+})

--- a/dashboard/__tests__/permitBotState.test.mjs
+++ b/dashboard/__tests__/permitBotState.test.mjs
@@ -1,0 +1,85 @@
+// Tests for the permit-bot session-log → dashboard-state reducer.
+//
+// The reducer's job is to surface high-signal events from a session JSONL
+// log. After we started writing `poll_recovered` events on every successful
+// poll that followed a backoff, the filter had to learn two new event types
+// (`poll_error` + `poll_recovered`) so the dashboard pairs the hit with the
+// comeback instead of going silent after a 429.
+
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { readPermitBotState } from '../permitBotState.mjs'
+
+function writeLog(dir, name, events) {
+    const lines = events.map(e => JSON.stringify(e)).join('\n') + '\n'
+    writeFileSync(path.join(dir, name), lines)
+}
+
+describe('readPermitBotState', () => {
+    let tmp
+    let prevEnv
+
+    beforeEach(() => {
+        tmp = mkdtempSync(path.join(tmpdir(), 'permit-bot-log-'))
+        prevEnv = process.env.PERMIT_BOT_LOG_DIR
+        process.env.PERMIT_BOT_LOG_DIR = tmp
+    })
+
+    afterEach(() => {
+        if (prevEnv === undefined) delete process.env.PERMIT_BOT_LOG_DIR
+        else process.env.PERMIT_BOT_LOG_DIR = prevEnv
+        rmSync(tmp, { recursive: true, force: true })
+    })
+
+    test('present=false when no session log exists', () => {
+        const state = readPermitBotState()
+        expect(state.present).toBe(false)
+    })
+
+    test('surfaces poll_error and poll_recovered in recentEvents', () => {
+        writeLog(tmp, 'watch-auto-2026-06-26.jsonl', [
+            { ts: '2026-06-26T07:40:00Z', event: 'startup', targets: ['HI', 'GP'], pollIntervalMs: 20000 },
+            { ts: '2026-06-26T07:40:14Z', event: 'poll_error', error: 'Request failed with status code 429', backoffMs: 4000 },
+            { ts: '2026-06-26T07:40:34Z', event: 'poll_recovered', priorBackoffMs: 4000 },
+            { ts: '2026-06-26T07:40:35Z', event: 'poll', count: 1, byDate: {}, durationMs: 200 },
+        ])
+
+        const state = readPermitBotState()
+        expect(state.present).toBe(true)
+        const types = state.recentEvents.map(e => e.type)
+        expect(types).toContain('poll_error')
+        expect(types).toContain('poll_recovered')
+
+        const recovered = state.recentEvents.find(e => e.type === 'poll_recovered')
+        expect(recovered.priorBackoffMs).toBe(4000)
+        const errored = state.recentEvents.find(e => e.type === 'poll_error')
+        expect(errored.backoffMs).toBe(4000)
+        expect(errored.error).toMatch(/429/)
+    })
+
+    test('errors metric counts poll_error events independent of the recentEvents cap', () => {
+        const events = [{ ts: '2026-06-26T07:00:00Z', event: 'startup' }]
+        for (let i = 0; i < 3; i++) {
+            events.push({ ts: `2026-06-26T07:0${i}:00Z`, event: 'poll_error', error: '429', backoffMs: 1000 << i })
+        }
+        writeLog(tmp, 'watch-auto-2026-06-26.jsonl', events)
+
+        const state = readPermitBotState()
+        expect(state.metrics.errors).toBe(3)
+    })
+
+    test('low-signal events (prewarm, warm_dom_inventory) are filtered out', () => {
+        writeLog(tmp, 'watch-auto-2026-06-26.jsonl', [
+            { ts: '2026-06-26T07:00:00Z', event: 'startup' },
+            { ts: '2026-06-26T07:00:01Z', event: 'prewarm', accountIndex: 0, ok: true },
+            { ts: '2026-06-26T07:00:02Z', event: 'warm_dom_inventory', rows: 12 },
+            { ts: '2026-06-26T07:00:03Z', event: 'heartbeat', uptimeMin: 1, pollCount: 1 },
+        ])
+
+        const types = readPermitBotState().recentEvents.map(e => e.type)
+        expect(types).not.toContain('prewarm')
+        expect(types).not.toContain('warm_dom_inventory')
+        expect(types).toContain('heartbeat')
+    })
+})

--- a/dashboard/botState.mjs
+++ b/dashboard/botState.mjs
@@ -37,6 +37,20 @@ export function appendEvent(state, event) {
     }
 }
 
+// Atomic "reset backoff + emit recovery" pair. Without this, a 429 burst
+// followed by silence on the dashboard makes it look like the bot is wedged
+// when in fact the next cycle succeeded — emit() runs only when we were
+// actually backed off, so quiet recoveries don't spam the event stream.
+// Wrapping both steps stops a future caller from resetting backoff without
+// also publishing the recovery, which is the actual bug we want to lock out.
+export function resetBackoffWithRecovery(checker, emit) {
+    const priorBackoffMs = checker.backoffMs
+    checker.resetBackoff()
+    if (priorBackoffMs > 0) {
+        emit({ priorBackoffMs })
+    }
+}
+
 // Liveness from a heartbeat timestamp + the bot's poll interval. We tolerate
 // a 3× expected interval before declaring "stale" — accounts for slow cycles
 // (cart automation takes 10-30s) without blinking the dashboard.

--- a/dashboard/dashboardPage.mjs
+++ b/dashboard/dashboardPage.mjs
@@ -104,6 +104,7 @@ export const DASHBOARD_PAGE_HTML = `<!doctype html>
   .ev .type.cart_attempt { color: var(--accent-2); }
   .ev .type.skipped_cooldown { color: var(--ink-dim); }
   .ev .type.poll_error { color: var(--warn); }
+  .ev .type.poll_recovered { color: var(--accent); }
   .ev .type.heartbeat { color: var(--ink-dim); }
   .ev .body { color: var(--ink); }
 
@@ -213,6 +214,8 @@ export const DASHBOARD_PAGE_HTML = `<!doctype html>
                 ? 'mode=' + escape(e.mode || '—')
               : e.type === 'poll_error'
                 ? escape(e.error || '') + ' (backoff ' + escape(e.backoffMs ?? 0) + 'ms)'
+              : e.type === 'poll_recovered'
+                ? 'poll ok again (cleared ' + escape(e.priorBackoffMs ?? 0) + 'ms backoff)'
               : e.type === 'decision_skipped'
                 ? escape(e.date) + ' skipped: ' + escape(e.reason || '')
               : e.type === 'verify_config'

--- a/dashboard/permitBotState.mjs
+++ b/dashboard/permitBotState.mjs
@@ -58,9 +58,10 @@ export function readPermitBotState() {
     const errors = events.filter(e => e.event === 'poll_error').length
     // High-signal events only — prewarm + warm_dom_inventory fire once at
     // startup and dwarf everything else. Keep verify_config / warm_row_check
-    // because they surface drift.
+    // because they surface drift. poll_error + poll_recovered are paired so
+    // the dashboard shows both the hit and the comeback.
     const recentEvents = events
-        .filter(e => /^(decision|decision_skipped|fire_results|warm_row_check_failed|verify_config|heartbeat|shutdown)$/.test(e.event))
+        .filter(e => /^(decision|decision_skipped|fire_results|warm_row_check_failed|verify_config|heartbeat|shutdown|poll_error|poll_recovered)$/.test(e.event))
         .slice(-30)
         .reverse()
         .map(e => ({ type: e.event, ts: e.ts, ...e }))

--- a/permit-bot/permit-bot.mjs
+++ b/permit-bot/permit-bot.mjs
@@ -15,6 +15,7 @@ import { decide } from './decision.mjs'
 import { httpsAgent } from './dnsBypass.mjs'
 import { benchmarkPolling } from './benchmark.mjs'
 import { runChartCommand, latestSessionLogPath } from './chart.mjs'
+import { resetBackoffWithRecovery } from '../dashboard/botState.mjs'
 
 const log = {
     info: (msg) => console.log(`[${new Date().toISOString()}] ${msg}`),
@@ -801,7 +802,8 @@ async function cmdWatchAuto({
         try {
             const payload = await checker.pollOnce()
             const { snapshot } = checker.diff(payload)
-            checker.resetBackoff()
+            resetBackoffWithRecovery(checker, ({ priorBackoffMs }) =>
+                session.write('poll_recovered', { priorBackoffMs }))
             pollCount += 1
 
             // Build {date -> {hi, gp}} from snapshot rows.


### PR DESCRIPTION
## Summary
- After a 429, the dashboard event stream showed `poll_error … (backoff 4000ms)` and then went silent — no way to tell whether the bot resumed or wedged.
- Both bots now emit a paired `poll_recovered` event on the first successful poll after a non-zero backoff. Renders green on the dashboard: `poll ok again (cleared 4000ms backoff)`.
- Extracted `resetBackoffWithRecovery(checker, emit)` into `dashboard/botState.mjs` so the reset + recovery emission are atomic — locks out the bug where a future caller could clear backoff without publishing recovery.
- Permit-bot reducer (`dashboard/permitBotState.mjs`) now surfaces both `poll_error` and `poll_recovered` in `recentEvents` (previously poll_error was filtered out, so the permit-bot card silently swallowed errors too).

## Test plan
- [x] `npm test` — 233 pass (9 new across two new files under `dashboard/__tests__/`)
- [x] `botState.test.mjs` covers the helper directly: emits-when-backed-off, skips-when-clean, captures-before-reset (regression guard), integrates with `appendEvent`, survives a throwing emit
- [x] `permitBotState.test.mjs` covers the reducer: poll_error + poll_recovered now appear in recentEvents with their backoff fields preserved; low-signal events stay filtered out
- [ ] Smoke test on the dashboard after a real 429 (will eyeball next time rec.gov throttles us)

🤖 Generated with [Claude Code](https://claude.com/claude-code)