### PR TITLE
feat(permit-bot): auto-rolling target dates via offsets

### DIFF
--- a/permit-bot/__tests__/dateRoll.test.mjs
+++ b/permit-bot/__tests__/dateRoll.test.mjs
@@ -1,0 +1,156 @@
+import { todayInPT, getActiveTargetDates, describeActiveDates } from '../dateRoll.mjs'
+
+// Pin "now" to known UTC instants so PT crossings are deterministic.
+// 2026-06-12 14:00 UTC = 07:00 PT (release moment for night 06-19).
+const PT_0700_2026_06_12 = new Date('2026-06-12T14:00:00Z')
+// 2026-06-13 06:30 UTC = 23:30 PT on 06-12 (still "yesterday" in PT).
+const PT_2330_2026_06_12 = new Date('2026-06-13T06:30:00Z')
+// 2026-06-13 07:30 UTC = 00:30 PT on 06-13 (just past midnight PT).
+const PT_0030_2026_06_13 = new Date('2026-06-13T07:30:00Z')
+
+describe('todayInPT()', () => {
+    test('returns the PT calendar day, not the UTC day', () => {
+        // At 06:30 UTC on 06-13, PT clock reads 23:30 on 06-12 — still 06-12.
+        expect(todayInPT(PT_2330_2026_06_12)).toBe('2026-06-12')
+    })
+
+    test('rolls over at midnight PT', () => {
+        expect(todayInPT(PT_0030_2026_06_13)).toBe('2026-06-13')
+    })
+
+    test('handles 7am PT release moment', () => {
+        expect(todayInPT(PT_0700_2026_06_12)).toBe('2026-06-12')
+    })
+})
+
+describe('getActiveTargetDates() — auto-roll (offsets) mode', () => {
+    test('[7, 8] on 2026-06-12 PT → next two release nights', () => {
+        const cfg = { targetDateOffsetsDays: [7, 8] }
+        expect(getActiveTargetDates(cfg, PT_0700_2026_06_12)).toEqual([
+            '2026-06-19',
+            '2026-06-20',
+        ])
+    })
+
+    test('same offsets one day later rolls forward', () => {
+        const cfg = { targetDateOffsetsDays: [7, 8] }
+        expect(getActiveTargetDates(cfg, PT_0030_2026_06_13)).toEqual([
+            '2026-06-20',
+            '2026-06-21',
+        ])
+    })
+
+    test('offsets win when both fields are present', () => {
+        const cfg = {
+            targetDateOffsetsDays: [7],
+            targetDates: ['2099-01-01'],
+        }
+        expect(getActiveTargetDates(cfg, PT_0700_2026_06_12)).toEqual(['2026-06-19'])
+    })
+
+    test('dedupes overlapping offsets', () => {
+        const cfg = { targetDateOffsetsDays: [7, 7, 8] }
+        expect(getActiveTargetDates(cfg, PT_0700_2026_06_12)).toEqual([
+            '2026-06-19',
+            '2026-06-20',
+        ])
+    })
+
+    test('single offset works', () => {
+        const cfg = { targetDateOffsetsDays: [7] }
+        expect(getActiveTargetDates(cfg, PT_0700_2026_06_12)).toEqual(['2026-06-19'])
+    })
+
+    test('offsets crossing a month boundary compute correctly', () => {
+        // 2026-06-25 + 7 = 2026-07-02
+        const onJune25 = new Date('2026-06-25T18:00:00Z') // 11am PT
+        expect(getActiveTargetDates({ targetDateOffsetsDays: [7] }, onJune25)).toEqual([
+            '2026-07-02',
+        ])
+    })
+
+    test('non-numeric offsets are silently dropped', () => {
+        const cfg = { targetDateOffsetsDays: [7, 'oops', null, 8] }
+        expect(getActiveTargetDates(cfg, PT_0700_2026_06_12)).toEqual([
+            '2026-06-19',
+            '2026-06-20',
+        ])
+    })
+
+    test('empty offsets array falls through to static list', () => {
+        const cfg = {
+            targetDateOffsetsDays: [],
+            targetDates: ['2026-06-19'],
+        }
+        expect(getActiveTargetDates(cfg, PT_0700_2026_06_12)).toEqual(['2026-06-19'])
+    })
+})
+
+describe('getActiveTargetDates() — static list mode', () => {
+    test('keeps today + future, drops past', () => {
+        const cfg = {
+            targetDates: ['2026-06-10', '2026-06-12', '2026-06-19', '2026-06-20'],
+        }
+        // today=2026-06-12 → keep 06-12 (same day), 06-19, 06-20; drop 06-10.
+        expect(getActiveTargetDates(cfg, PT_0700_2026_06_12)).toEqual([
+            '2026-06-12',
+            '2026-06-19',
+            '2026-06-20',
+        ])
+    })
+
+    test('all-past list returns empty', () => {
+        const cfg = { targetDates: ['2026-06-01', '2026-06-05'] }
+        expect(getActiveTargetDates(cfg, PT_0700_2026_06_12)).toEqual([])
+    })
+
+    test('dedupes and sorts', () => {
+        const cfg = {
+            targetDates: ['2026-06-20', '2026-06-19', '2026-06-20'],
+        }
+        expect(getActiveTargetDates(cfg, PT_0700_2026_06_12)).toEqual([
+            '2026-06-19',
+            '2026-06-20',
+        ])
+    })
+
+    test('ignores malformed entries', () => {
+        const cfg = {
+            targetDates: ['2026-06-19', 'tomorrow', '2026/06/20', null, '2026-06-21'],
+        }
+        expect(getActiveTargetDates(cfg, PT_0700_2026_06_12)).toEqual([
+            '2026-06-19',
+            '2026-06-21',
+        ])
+    })
+
+    test('missing config returns empty', () => {
+        expect(getActiveTargetDates({}, PT_0700_2026_06_12)).toEqual([])
+    })
+
+    test('static list survives crossing into a date (boundary at midnight PT)', () => {
+        const cfg = { targetDates: ['2026-06-13'] }
+        // Just before midnight PT on 06-12 → today=06-12 → keep 06-13
+        expect(getActiveTargetDates(cfg, PT_2330_2026_06_12)).toEqual(['2026-06-13'])
+        // Just after midnight PT on 06-13 → today=06-13 → still keep 06-13 (same day)
+        expect(getActiveTargetDates(cfg, PT_0030_2026_06_13)).toEqual(['2026-06-13'])
+    })
+})
+
+describe('describeActiveDates()', () => {
+    test('auto-roll mode notes offsets', () => {
+        const s = describeActiveDates({ targetDateOffsetsDays: [7, 8] }, PT_0700_2026_06_12)
+        expect(s).toMatch(/auto-roll/)
+        expect(s).toMatch(/2026-06-19/)
+        expect(s).toMatch(/2026-06-20/)
+    })
+
+    test('static mode flags dropped past dates', () => {
+        const s = describeActiveDates(
+            { targetDates: ['2026-06-10', '2026-06-19'] },
+            PT_0700_2026_06_12,
+        )
+        expect(s).toMatch(/static/)
+        expect(s).toMatch(/dropped past.*2026-06-10/)
+    })
+})

--- a/permit-bot/config.json
+++ b/permit-bot/config.json
@@ -13,7 +13,8 @@
       "nameTokens": ["Glacier Point", "Little Yosemite Valley"]
     }
   ],
-  "targetDates": ["2026-06-19", "2026-06-20"],
+  "targetDateOffsetsDays": [7, 8],
+  "_targetDates_comment": "Auto-roll: each day at midnight PT the active set advances by 1. [7,8] means we always monitor the night that released this morning at 7am PT plus the night that releases tomorrow at 7am. To pin to specific calendar dates instead (e.g. trip-locked), delete targetDateOffsetsDays and set: \"targetDates\": [\"YYYY-MM-DD\", ...]",
   "partySize": 7,
   "pollIntervalMs": 1500,
   "burstWindow": {

--- a/permit-bot/dateRoll.mjs
+++ b/permit-bot/dateRoll.mjs
@@ -1,0 +1,91 @@
+// Date selection for the LYV race window.
+//
+// Yosemite Wilderness Permits release at 7am Pacific Time, 7 days in advance.
+// On any given calendar day in PT, exactly one night becomes raceable that
+// morning (today+7). Bots that run for multiple days need their target-date
+// set to *roll forward* as the calendar advances — otherwise they either
+// (a) waste polling on stale past dates, or (b) require manual config edits
+// after each race.
+//
+// Two config modes:
+//
+//   1. AUTO-ROLL (preferred for long-running monitors):
+//        { "targetDateOffsetsDays": [7, 8] }
+//      Each cycle we compute today+offsetN dates. Past midnight PT, the set
+//      naturally advances by one day. Default `[7, 8]` covers "the night that
+//      released this morning at 7am PT" plus "the night that releases tomorrow
+//      at 7am" — giving cross-midnight runs a hand-off without manual restart.
+//
+//   2. STATIC LIST (preferred when you have specific trip dates):
+//        { "targetDates": ["2026-06-19", "2026-06-20"] }
+//      We drop any date strictly earlier than today (PT). Future dates poll
+//      as before. Once all dates pass, the active set goes empty and the
+//      watcher exits.
+//
+// If both fields are present, AUTO-ROLL wins. The static list is treated as
+// "lock to these specific dates" so it stays the explicit-opt-in escape hatch.
+
+const PT_TZ = 'America/Los_Angeles'
+
+// "Today" as the rec.gov release timezone sees it. Independent of process
+// timezone — a Mac running in UTC, a NAS in EST, and the rec.gov clock all
+// agree on which night just released.
+export function todayInPT(now = new Date()) {
+    const parts = new Intl.DateTimeFormat('en-CA', {
+        timeZone: PT_TZ,
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit',
+    }).formatToParts(now)
+    const yyyy = parts.find(p => p.type === 'year').value
+    const mm = parts.find(p => p.type === 'month').value
+    const dd = parts.find(p => p.type === 'day').value
+    return `${yyyy}-${mm}-${dd}`
+}
+
+function addDaysISO(yyyyMmDd, n) {
+    const [y, m, d] = yyyyMmDd.split('-').map(Number)
+    const dt = new Date(Date.UTC(y, m - 1, d))
+    dt.setUTCDate(dt.getUTCDate() + n)
+    const yy = dt.getUTCFullYear()
+    const mo = String(dt.getUTCMonth() + 1).padStart(2, '0')
+    const da = String(dt.getUTCDate()).padStart(2, '0')
+    return `${yy}-${mo}-${da}`
+}
+
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/
+
+// Deterministic, deduped, sorted ascending. Caller passes `now` in tests to
+// pin behavior across midnight boundaries.
+export function getActiveTargetDates(config, now = new Date()) {
+    const today = todayInPT(now)
+    const offsets = config.targetDateOffsetsDays
+    if (Array.isArray(offsets) && offsets.length > 0) {
+        const out = new Set()
+        for (const off of offsets) {
+            // Reject null/undefined/'' explicitly — Number(null) is 0, which
+            // would silently add today as a target.
+            if (off === null || off === undefined || off === '') continue
+            const n = Number(off)
+            if (!Number.isFinite(n)) continue
+            out.add(addDaysISO(today, Math.trunc(n)))
+        }
+        return [...out].sort()
+    }
+    const list = Array.isArray(config.targetDates) ? config.targetDates : []
+    return [...new Set(list.filter(d => typeof d === 'string' && ISO_DATE_RE.test(d) && d >= today))].sort()
+}
+
+// Human summary for logs/heartbeats: explains *why* the active set is what it
+// is, so a glance at startup confirms the right config mode is live.
+export function describeActiveDates(config, now = new Date()) {
+    const today = todayInPT(now)
+    const active = getActiveTargetDates(config, now)
+    if (Array.isArray(config.targetDateOffsetsDays) && config.targetDateOffsetsDays.length) {
+        return `auto-roll today=${today} offsets=${JSON.stringify(config.targetDateOffsetsDays)} → ${active.join(', ') || '(empty)'}`
+    }
+    const raw = Array.isArray(config.targetDates) ? config.targetDates : []
+    const dropped = raw.filter(d => d < today)
+    const droppedNote = dropped.length ? ` (dropped past: ${dropped.join(', ')})` : ''
+    return `static today=${today} dates=${active.join(', ') || '(empty)'}${droppedNote}`
+}

--- a/permit-bot/permit-bot.mjs
+++ b/permit-bot/permit-bot.mjs
@@ -16,6 +16,7 @@ import { httpsAgent } from './dnsBypass.mjs'
 import { benchmarkPolling } from './benchmark.mjs'
 import { runChartCommand, latestSessionLogPath } from './chart.mjs'
 import { resetBackoffWithRecovery } from '../dashboard/botState.mjs'
+import { getActiveTargetDates, describeActiveDates, todayInPT } from './dateRoll.mjs'
 
 const log = {
     info: (msg) => console.log(`[${new Date().toISOString()}] ${msg}`),
@@ -198,10 +199,16 @@ async function cmdVerifyConfig() {
         // explicitly (older configs without the field still get token matching).
         nameTokens: t.nameTokens || [t.name.split('->')[0].trim(), t.name.split(' (')[0].split('->').pop().trim()],
     }))
-    log.info(`verify-config: probing ${targets.length} targets against live rec.gov`)
+    const activeDates = getActiveTargetDates(config)
+    const probeDate = activeDates[0] || config.targetDates?.[0]
+    if (!probeDate) {
+        console.error('verify-config: no active target dates available (config exhausted). Update config.json.')
+        process.exit(1)
+    }
+    log.info(`verify-config: probing ${targets.length} targets against live rec.gov (date=${probeDate})`)
     const result = await verifyConfigOnce({
         permitId: config.permitId,
-        date: config.targetDates[0],
+        date: probeDate,
         partySize: config.partySize,
         targets,
         log,
@@ -220,10 +227,16 @@ async function cmdVerifyConfig() {
 
 async function cmdProbe() {
     const config = loadConfig()
+    const activeDates = getActiveTargetDates(config)
+    if (activeDates.length === 0) {
+        console.error(`probe: no active target dates. ${describeActiveDates(config)}`)
+        process.exit(1)
+    }
+    log.info(`probe: ${describeActiveDates(config)}`)
     const checker = new PermitChecker({
         permitId: config.permitId,
         targets: config.targets,
-        targetDates: config.targetDates,
+        targetDates: activeDates,
         log,
     })
     const payload = await checker.pollOnce()
@@ -421,10 +434,26 @@ async function cmdWatchAuto({
     const GP_TOKENS = simulate ? ['Cottonwood Creek'] : ['Glacier Point', 'Little Yosemite Valley']
     const HI_TARGET = { divisionId: HI_ID, name: HI_NAME, nameTokens: HI_TOKENS }
     const GP_TARGET = { divisionId: GP_ID, name: GP_NAME, nameTokens: GP_TOKENS }
+
+    // Active dates roll forward with the calendar. We recompute every loop
+    // iteration so a watch-auto left running across midnight PT picks up
+    // the next release night automatically (offsets mode) or drops past
+    // dates (static mode). Empty set at startup = nothing to race — bail
+    // loudly rather than silently polling zero divisions.
+    let activeDates = getActiveTargetDates(config)
+    if (activeDates.length === 0) {
+        log.error(`watch-auto: no active target dates. ${describeActiveDates(config)}`)
+        await discordPush([
+            '🔴 **watch-auto refused to start: no active target dates**',
+            `\`${describeActiveDates(config)}\``,
+            'Update `permit-bot/config.json` (set `targetDateOffsetsDays` or refresh `targetDates`) and re-run.',
+        ].join('\n'))
+        return
+    }
     const checker = new PermitChecker({
         permitId: config.permitId,
         targets: [HI_TARGET, GP_TARGET],
-        targetDates: config.targetDates,
+        targetDates: activeDates,
         log,
     })
 
@@ -488,10 +517,12 @@ async function cmdWatchAuto({
         second: '2-digit',
     }).format(new Date(iso))
 
-    log.info(`watch-auto: targets=LYV (HI+GP), dates=${config.targetDates.join(', ')}, poll=${config.pollIntervalMs}ms, preWarm=${preWarm}`)
+    log.info(`watch-auto: targets=LYV (HI+GP), dates=${activeDates.join(', ')}, poll=${config.pollIntervalMs}ms, preWarm=${preWarm}`)
+    log.info(`Date selection: ${describeActiveDates(config)}`)
     log.info(`Session log: ${session.filePath}`)
     session.write('startup', {
-        targets: config.targetDates,
+        targets: activeDates,
+        dateSelection: describeActiveDates(config),
         pollIntervalMs: config.pollIntervalMs,
         preWarm,
         simulate,
@@ -502,7 +533,8 @@ async function cmdWatchAuto({
     // Startup Discord ping so you know the monitor is up.
     await discordPush([
         '🟢 **watch-auto started**',
-        `**Dates:** ${config.targetDates.join(', ')}`,
+        `**Dates:** ${activeDates.join(', ')}`,
+        `**Date selection:** \`${describeActiveDates(config)}\``,
         `**Poll interval:** ${config.pollIntervalMs}ms`,
         `**Pre-warm:** ${preWarm ? 'on (acct1 HI party=7)' : 'off'}`,
         `**Mode:** ${simulate ? 'SIMULATE → Cottonwood Creek' : 'LYV LIVE'}`,
@@ -528,7 +560,7 @@ async function cmdWatchAuto({
         const expectedTargets = [HI_TARGET, GP_TARGET]
         const results = await Promise.allSettled(specs.map(spec => warmCart({
             permitId: config.permitId,
-            date: config.targetDates[0],
+            date: activeDates[0],
             partySize: spec.partySize,
             accountIndex: spec.accountIndex,
             expectedTargets,
@@ -799,6 +831,34 @@ async function cmdWatchAuto({
     // Main poll loop.
     while (!firedThisRun) {
         const tickStart = Date.now()
+
+        // Re-derive active dates each tick. In offsets mode this auto-rolls
+        // across midnight PT; in static mode it drops dates as they pass.
+        // Cheap (just date arithmetic) so we can do it every poll.
+        const newActiveDates = getActiveTargetDates(config)
+        if (newActiveDates.length === 0) {
+            log.error(`watch-auto: active dates set went empty. ${describeActiveDates(config)}. Exiting.`)
+            await discordPush([
+                '🔴 **watch-auto exiting: no active target dates left**',
+                `\`${describeActiveDates(config)}\``,
+                'All configured dates have passed. Update `permit-bot/config.json` and restart.',
+            ].join('\n'))
+            session.write('shutdown_no_dates', { describe: describeActiveDates(config) })
+            break
+        }
+        if (newActiveDates.join(',') !== activeDates.join(',')) {
+            log.info(`active dates rolled: ${activeDates.join(',')} → ${newActiveDates.join(',')}`)
+            session.write('dates_rolled', { from: activeDates, to: newActiveDates })
+            await discordPush([
+                '🔄 **watch-auto rolled target dates**',
+                `**From:** ${activeDates.join(', ') || '(empty)'}`,
+                `**To:** ${newActiveDates.join(', ')}`,
+                `_${describeActiveDates(config)}_`,
+            ].join('\n'))
+            activeDates = newActiveDates
+            checker.targetDates = activeDates
+        }
+
         try {
             const payload = await checker.pollOnce()
             const { snapshot } = checker.diff(payload)
@@ -893,7 +953,7 @@ async function cmdWatchAuto({
                 try {
                     const verifyResult = await verifyConfigOnce({
                         permitId: config.permitId,
-                        date: config.targetDates[0],
+                        date: activeDates[0],
                         partySize: config.partySize,
                         targets: [HI_TARGET, GP_TARGET],
                         log: { info: () => {}, warn: log.warn, error: log.error },
@@ -936,12 +996,9 @@ async function cmdWatchAuto({
 
             // Per-cell window summary. One line per (date, division) showing
             // how the API ticked across the heartbeat window. Order: dates by
-            // target list, divisions HI then GP.
-            const datesForWindow = config.targetDates.length
-                ? [...config.targetDates].sort()
-                : [...new Set([...windowStats.keys()].map(k => k.split('|')[0]))].sort()
+            // active list, divisions HI then GP.
             const windowLines = []
-            for (const d of datesForWindow) {
+            for (const d of activeDates) {
                 for (const divName of ['hi', 'gp']) {
                     const key = `${d}|${divName}`
                     const stats = windowStats.get(key)
@@ -967,7 +1024,7 @@ async function cmdWatchAuto({
             // current floor, how many polls in the window had enough stock.
             // Direct answer to "should I lower partyTargets?" Reset alongside.
             const wfLines = []
-            for (const d of datesForWindow) {
+            for (const d of activeDates) {
                 const wf = wouldFireStats.get(d)
                 if (!wf) continue
                 const cells = WOULD_FIRE_SIZES
@@ -1002,6 +1059,7 @@ async function cmdWatchAuto({
                 `💓 **watch-auto heartbeat** ${statusEmoji}`,
                 `**Uptime:** ${uptimeMin} min`,
                 `**Polls:** ${pollCount}`,
+                `**Today (PT):** ${todayInPT()} → **active dates:** ${activeDates.join(', ')}`,
                 `**Last snapshot:** ${lastSnapshotSummary}`,
                 `**API window (last ${Math.round(HEARTBEAT_MS / 60000)} min):**`,
                 ...windowLines.map(l => `  ${l}`),
@@ -1050,10 +1108,15 @@ async function cmdWatchAuto({
 
 async function cmdWatch({ autoGrab = false } = {}) {
     const config = loadConfig()
+    let activeDates = getActiveTargetDates(config)
+    if (activeDates.length === 0) {
+        log.error(`watch: no active target dates. ${describeActiveDates(config)}`)
+        process.exit(1)
+    }
     const checker = new PermitChecker({
         permitId: config.permitId,
         targets: config.targets,
-        targetDates: config.targetDates,
+        targetDates: activeDates,
         log,
     })
 
@@ -1062,11 +1125,25 @@ async function cmdWatch({ autoGrab = false } = {}) {
     const fired = new Set()
     let grabInFlight = false
 
-    log.info(`Watching permit ${config.permitId} for ${config.targetDates.join(', ')}`)
+    log.info(`Watching permit ${config.permitId} for ${activeDates.join(', ')}`)
+    log.info(`Date selection: ${describeActiveDates(config)}`)
     log.info(`Targets: ${config.targets.map(t => t.name).join(' | ')}`)
     log.info(`Auto-grab: ${autoGrab ? 'ON' : 'OFF (notify only)'}; ntfy: ${NTFY_TOPIC_URL ? 'on' : 'off'}`)
 
     while (true) {
+        // Same per-tick recompute as watch-auto — drops past dates, rolls
+        // offsets, keeps `checker.targetDates` honest across midnight PT.
+        const newActiveDates = getActiveTargetDates(config)
+        if (newActiveDates.length === 0) {
+            log.error(`watch: active dates exhausted. ${describeActiveDates(config)}. Exiting.`)
+            break
+        }
+        if (newActiveDates.join(',') !== activeDates.join(',')) {
+            log.info(`active dates rolled: ${activeDates.join(',')} → ${newActiveDates.join(',')}`)
+            activeDates = newActiveDates
+            checker.targetDates = activeDates
+        }
+
         const intervalMs = pickIntervalMs(config)
         const start = Date.now()
         try {


### PR DESCRIPTION
## Summary
Long-running permit-bot watchers wasted polling on past dates and required manual config edits after each 7am PT release. This wires in a new `dateRoll.mjs` module so the active date set is recomputed every poll cycle:

- **Default (auto-roll):** `"targetDateOffsetsDays": [7, 8]` — always monitors today+7 and today+8 (PT). Across midnight PT the set rolls forward; cross-day runs hand off without manual restart.
- **Escape hatch (static):** `"targetDates": [...]` — pinned dates; past entries auto-drop; empty set causes a clean exit with a 🔴 Discord ping.
- **Both present → offsets win** (static is the explicit opt-in).

Wired through `verify-config`, `probe`, `watch`, and `watch-auto`. Date rolls emit a `dates_rolled` session-log event and a 🔄 Discord notification; heartbeats now include `Today (PT) → active dates` so the operator can confirm the right set is live.

`config.json` flipped from the now-stale static `["2026-06-19", "2026-06-20"]` to `targetDateOffsetsDays: [7, 8]`, with an inline `_targetDates_comment` explaining the toggle.

Upstream `f99c2db` (heartbeat 30m → 6h) merged cleanly in the rebase.

## Test plan
- [x] `npm test` — 247 passing (228 prior + 19 new dateRoll cases covering offsets, static-with-past-drop, dedupe, malformed input, midnight-PT boundary, mode-description strings)
- [ ] Deploy and confirm the next heartbeat shows `Today (PT) → active dates: <today+7>, <today+8>`
- [ ] Verify a `🔄 watch-auto rolled target dates` ping fires on the first midnight-PT crossing after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)