### PR TITLE
feat(campspot-bot): multi-campground watch (Yosemite alternates)

### DIFF
--- a/campspot-bot/README.md
+++ b/campspot-bot/README.md
@@ -4,9 +4,18 @@ Sibling to `permit-bot/`. Watches a rec.gov **campground** (not permit) for
 Thu–Sun stays in a configurable window and (optionally) drives Playwright to
 add the slot to the user's cart so the hold sticks for 15 minutes.
 
-Target campground is set in `campspot-bot/config.json`. Defaults to Upper
-Pines (id `232447`), window `2026-06-22 → 2026-09-30`, weekdays Thu/Fri/Sat/Sun,
-max 4-night stays.
+Targets are set in `campspot-bot/config.json` as `{ shared, campgrounds[] }`.
+`shared` covers the targeting window / weekdays / nights; each entry in
+`campgrounds[]` adds a `{ campgroundId, campgroundName, park }` and can
+override any shared field. Ships with the eight reservable Yosemite
+campgrounds (Upper/Lower/North Pines, Hodgdon Meadow, Crane Flat, Wawona,
+Bridalveil Creek, Tuolumne Meadows). Legacy single-campground configs
+(everything at the top level) still load — they're normalized to a
+one-element list at read time.
+
+Run one watch per campground; `--campground=ID` picks which entry. State
+files are written per id (`state/status-<id>.json`) so processes don't
+stomp each other and the dashboard renders one card per running bot.
 
 Re-uses the rec.gov login from `permit-bot/.chromium-profile`, so run
 `node permit-bot/permit-bot.mjs login --account=1` once before any
@@ -15,28 +24,44 @@ Re-uses the rec.gov login from `permit-bot/.chromium-profile`, so run
 ## Commands
 
 ```
-node campspot-bot/campspot-bot.mjs check
+node campspot-bot/campspot-bot.mjs check [--campground=ID]
   # one-shot scan of every campsite, prints qualifying Thu-Sun stays
   # (ranked: longest first, earliest first, lowest site #).
+  # Defaults to the first entry in config.campgrounds[].
 
-node campspot-bot/campspot-bot.mjs cart --site=068 --start=2026-09-10 --end=2026-09-14
+node campspot-bot/campspot-bot.mjs cart [--campground=ID] --site=068 --start=2026-09-10 --end=2026-09-14
   # dry-run cart flow: opens browser, advances the calendar, locates the
   # Available cell, screenshots. No clicks past the cell.
 
-node campspot-bot/campspot-bot.mjs cart --site=068 --start=2026-09-10 --end=2026-09-14 --for-real
+node campspot-bot/campspot-bot.mjs cart [--campground=ID] --site=068 --start=2026-09-10 --end=2026-09-14 --for-real
   # actually clicks "Add to Cart", verifies /cart hold, posts Discord with
   # the cart screenshot.
 
-node campspot-bot/campspot-bot.mjs watch
+node campspot-bot/campspot-bot.mjs watch [--campground=ID]
   # poll every config.pollIntervalMs; Discord/ntfy on NEW openings only.
 
-node campspot-bot/campspot-bot.mjs watch --auto-grab
+node campspot-bot/campspot-bot.mjs watch --campground=ID --auto-grab
   # same, but fires the cart bot on the top-ranked new stay (one at a time;
   # 1-hour cooldown per (site, dates) so we don't retry the same loss).
 
 node campspot-bot/campspot-bot.mjs release-cart [--account=N]
   # test-only: clears every hold from the account's cart.
 ```
+
+### Watching multiple campgrounds
+
+The bot is single-campground per process; fan out with one process per
+entry. Quick tmux pattern:
+
+```
+for id in 232447 232450 232449; do
+  tmux new-session -d -s "campspot-$id" \
+    "node campspot-bot/campspot-bot.mjs watch --campground=$id"
+done
+```
+
+The dashboard scans `campspot-bot/state/` and renders one card per running
+watch — no extra wiring needed.
 
 ## How the cart flow works
 

--- a/campspot-bot/__tests__/configLoader.test.mjs
+++ b/campspot-bot/__tests__/configLoader.test.mjs
@@ -1,0 +1,108 @@
+// Tests for the campspot-bot config normalizer.
+//
+// On-disk config grew a `{ shared, campgrounds[] }` shape so we can watch
+// multiple Yosemite campgrounds with one config. The loader has to keep
+// reading legacy single-campground files too — they were the only shape in
+// production until this change, and any deployment that hasn't been
+// re-rolled still has them on disk.
+
+import { normalizeRawConfig, selectCampground } from '../configLoader.mjs'
+
+describe('normalizeRawConfig', () => {
+    test('new shape: campgrounds[] is returned with shared merged in', () => {
+        const raw = {
+            shared: { pollIntervalMs: 30000, minNights: 2, targetWeekdays: ['Thu', 'Fri'] },
+            campgrounds: [
+                { campgroundId: '232447', campgroundName: 'Upper Pines', park: 'Yosemite' },
+                { campgroundId: '232450', campgroundName: 'Lower Pines', park: 'Yosemite' },
+            ],
+        }
+        const configs = normalizeRawConfig(raw)
+        expect(configs).toHaveLength(2)
+        expect(configs[0]).toMatchObject({
+            campgroundId: '232447',
+            campgroundName: 'Upper Pines',
+            park: 'Yosemite',
+            pollIntervalMs: 30000,
+            minNights: 2,
+            targetWeekdays: ['Thu', 'Fri'],
+        })
+        expect(configs[1].campgroundId).toBe('232450')
+        expect(configs[1].pollIntervalMs).toBe(30000)
+    })
+
+    test('per-campground field overrides shared', () => {
+        const raw = {
+            shared: { pollIntervalMs: 30000, minNights: 2 },
+            campgrounds: [
+                { campgroundId: '232447', campgroundName: 'Upper Pines', park: 'Yosemite' },
+                { campgroundId: '232448', campgroundName: 'Tuolumne', park: 'Yosemite', pollIntervalMs: 60000 },
+            ],
+        }
+        const configs = normalizeRawConfig(raw)
+        expect(configs[0].pollIntervalMs).toBe(30000)
+        expect(configs[1].pollIntervalMs).toBe(60000)
+        expect(configs[1].minNights).toBe(2)
+    })
+
+    test('legacy single-campground shape is normalized to a one-element list', () => {
+        const raw = {
+            campgroundId: '232447',
+            campgroundName: 'Upper Pines Campground',
+            park: 'Yosemite',
+            leadDays: 15,
+            rangeStartDate: '2026-06-22',
+            pollIntervalMs: 30000,
+            minNights: 2,
+        }
+        const configs = normalizeRawConfig(raw)
+        expect(configs).toHaveLength(1)
+        expect(configs[0]).toEqual({
+            campgroundId: '232447',
+            campgroundName: 'Upper Pines Campground',
+            park: 'Yosemite',
+            leadDays: 15,
+            rangeStartDate: '2026-06-22',
+            pollIntervalMs: 30000,
+            minNights: 2,
+        })
+    })
+
+    test('throws when campgrounds[] is empty', () => {
+        expect(() => normalizeRawConfig({ shared: {}, campgrounds: [] }))
+            .toThrow(/empty/)
+    })
+
+    test('throws when a campground entry is missing campgroundId', () => {
+        expect(() => normalizeRawConfig({
+            shared: {},
+            campgrounds: [{ campgroundName: 'No ID' }],
+        })).toThrow(/missing campgroundId/)
+    })
+
+    test('throws when neither new nor legacy shape is present', () => {
+        expect(() => normalizeRawConfig({ leadDays: 7 })).toThrow(/missing/)
+    })
+})
+
+describe('selectCampground', () => {
+    const configs = [
+        { campgroundId: '232447', campgroundName: 'Upper Pines' },
+        { campgroundId: '232450', campgroundName: 'Lower Pines' },
+    ]
+
+    test('returns the first entry when no id provided', () => {
+        expect(selectCampground(configs).campgroundId).toBe('232447')
+        expect(selectCampground(configs, null).campgroundId).toBe('232447')
+    })
+
+    test('matches by id (string or number)', () => {
+        expect(selectCampground(configs, '232450').campgroundId).toBe('232450')
+        expect(selectCampground(configs, 232450).campgroundId).toBe('232450')
+    })
+
+    test('throws with the known-ids list when id not found', () => {
+        expect(() => selectCampground(configs, '999999'))
+            .toThrow(/999999.*232447, 232450/)
+    })
+})

--- a/campspot-bot/campspot-bot.mjs
+++ b/campspot-bot/campspot-bot.mjs
@@ -2,7 +2,6 @@
 import * as dotenv from 'dotenv'
 dotenv.config()
 
-import { readFileSync } from 'node:fs'
 import { createReadStream } from 'node:fs'
 import path from 'node:path'
 import axios from 'axios'
@@ -11,10 +10,18 @@ import FormData from 'form-data'
 import CampspotChecker from './CampspotChecker.mjs'
 import { tryGrabCampsite, releaseCampspotCart, warmCampspotWindow } from './CampspotCartBot.mjs'
 import { windowDisplay } from './windowDisplay.mjs'
+import { loadConfigsFromFile, selectCampground } from './configLoader.mjs'
 import { httpsAgent } from '../permit-bot/dnsBypass.mjs'
 import { writeBotState, appendEvent, resetBackoffWithRecovery } from '../dashboard/botState.mjs'
 
-const STATE_FILE = path.resolve('./campspot-bot/state/status.json')
+const CONFIG_FILE = path.resolve('./campspot-bot/config.json')
+const STATE_DIR = path.resolve('./campspot-bot/state')
+
+// One state file per campground so multi-watch processes don't stomp each
+// other and the dashboard can scan the dir for every active bot.
+function stateFileFor(campgroundId) {
+    return path.join(STATE_DIR, `status-${campgroundId}.json`)
+}
 
 const log = {
     info: (msg) => console.log(`[${new Date().toISOString()}] ${msg}`),
@@ -30,9 +37,9 @@ const DISCORD_WEBHOOK_URL = process.env.CAMPSPOT_DISCORD_WEBHOOK_URL
     || null
 const NTFY_TOPIC_URL = process.env.NTFY_TOPIC_URL || null
 
-function loadConfig() {
-    const p = path.resolve('./campspot-bot/config.json')
-    return JSON.parse(readFileSync(p, 'utf-8'))
+function pickConfig(campgroundIdArg) {
+    const configs = loadConfigsFromFile(CONFIG_FILE)
+    return selectCampground(configs, campgroundIdArg)
 }
 
 async function discordPush(text, screenshotPath = null) {
@@ -95,8 +102,8 @@ function bookingUrl(campgroundId, s) {
     return `https://www.recreation.gov/camping/campgrounds/${campgroundId}?startdate=${s.startDate}&enddate=${s.endDate}`
 }
 
-async function cmdCheck() {
-    const config = loadConfig()
+async function cmdCheck({ campgroundId } = {}) {
+    const config = pickConfig(campgroundId)
     const checker = new CampspotChecker({
         campgroundId: config.campgroundId,
         rangeStartDate: config.rangeStartDate,
@@ -120,8 +127,8 @@ async function cmdCheck() {
     }
 }
 
-async function cmdCart({ overrides = {}, dryRun = true, accountIndex = 1 } = {}) {
-    const config = loadConfig()
+async function cmdCart({ overrides = {}, dryRun = true, accountIndex = 1, campgroundId } = {}) {
+    const config = pickConfig(campgroundId)
     if (!overrides.siteNo || !overrides.startDate || !overrides.endDate) {
         console.error('Usage: cart --site=068 --start=2026-06-22 --end=2026-06-23 [--for-real] [--account=N]')
         process.exit(2)
@@ -165,8 +172,8 @@ async function cmdRelease({ accountIndex = 1 } = {}) {
 // watch: poll continuously, notify on new openings. With --auto-grab, fires
 // CampspotCartBot on the highest-ranked new stay (sequentially — one cart at
 // a time so we don't trigger captchas).
-async function cmdWatch({ autoGrab = false, accountIndex = 1 } = {}) {
-    const config = loadConfig()
+async function cmdWatch({ autoGrab = false, accountIndex = 1, campgroundId } = {}) {
+    const config = pickConfig(campgroundId)
     const checker = new CampspotChecker({
         campgroundId: config.campgroundId,
         rangeStartDate: config.rangeStartDate,
@@ -226,7 +233,7 @@ async function cmdWatch({ autoGrab = false, accountIndex = 1 } = {}) {
         dashState.config.window = windowDisplay(
             config.rangeStartDate, config.rangeEndDate, config.leadDays, checker.effectiveStartDate(),
         )
-        try { writeBotState(STATE_FILE, dashState) } catch (err) {
+        try { writeBotState(stateFileFor(config.campgroundId), dashState) } catch (err) {
             log.warn(`state write failed: ${err.message}`)
         }
     }
@@ -520,12 +527,14 @@ const kv = Object.fromEntries(
 ;(async () => {
     try {
         const accountIndex = kv.account ? Number(kv.account) : 1
+        const campgroundId = kv.campground || null
         switch (subcommand) {
             case 'check':
-                await cmdCheck(); break
+                await cmdCheck({ campgroundId }); break
             case 'cart':
                 await cmdCart({
                     accountIndex,
+                    campgroundId,
                     dryRun: !flags.has('--for-real'),
                     overrides: {
                         siteNo: kv.site,
@@ -537,16 +546,17 @@ const kv = Object.fromEntries(
             case 'release-cart':
                 await cmdRelease({ accountIndex }); break
             case 'watch':
-                await cmdWatch({ autoGrab: flags.has('--auto-grab'), accountIndex }); break
+                await cmdWatch({ autoGrab: flags.has('--auto-grab'), accountIndex, campgroundId }); break
             default:
                 console.log(`Usage:
-  node campspot-bot/campspot-bot.mjs check                                  # one-shot availability scan
-  node campspot-bot/campspot-bot.mjs cart --site=068 --start=YYYY-MM-DD --end=YYYY-MM-DD [--for-real] [--account=N]
-                                                                            # dry-run by default; --for-real adds to cart
-  node campspot-bot/campspot-bot.mjs release-cart [--account=N]             # clear holds (test cleanup)
-  node campspot-bot/campspot-bot.mjs watch [--auto-grab] [--account=N]      # poll continuously, notify; --auto-grab fires the cart bot
+  node campspot-bot/campspot-bot.mjs check [--campground=ID]                              # one-shot availability scan
+  node campspot-bot/campspot-bot.mjs cart [--campground=ID] --site=068 --start=YYYY-MM-DD --end=YYYY-MM-DD [--for-real] [--account=N]
+                                                                                          # dry-run by default; --for-real adds to cart
+  node campspot-bot/campspot-bot.mjs release-cart [--account=N]                           # clear holds (test cleanup)
+  node campspot-bot/campspot-bot.mjs watch [--campground=ID] [--auto-grab] [--account=N]  # poll continuously, notify; --auto-grab fires the cart bot
 
-Edit campspot-bot/config.json for campgroundId / weekday filter / window.
+--campground=ID picks one entry from config.campgrounds[]; defaults to the first.
+Run one watch process per campground (tmux) to fan out across multiple targets.
 Re-uses the permit-bot rec.gov session — run \`node permit-bot/permit-bot.mjs login\` first.
 `)
                 process.exit(1)

--- a/campspot-bot/config.json
+++ b/campspot-bot/config.json
@@ -1,14 +1,23 @@
 {
-  "campgroundId": "232447",
-  "campgroundName": "Upper Pines Campground",
-  "park": "Yosemite",
-  "leadDays": 15,
-  "rangeStartDate": "2026-06-22",
-  "rangeEndDate": "2026-09-30",
-  "targetWeekdays": ["Thu", "Fri", "Sat", "Sun"],
-  "maxNights": 4,
-  "minNights": 2,
-  "minPeople": 6,
-  "pollIntervalMs": 30000,
-  "autoCart": false
+  "shared": {
+    "leadDays": 15,
+    "rangeStartDate": "2026-06-22",
+    "rangeEndDate": "2026-09-30",
+    "targetWeekdays": ["Thu", "Fri", "Sat", "Sun"],
+    "maxNights": 4,
+    "minNights": 2,
+    "minPeople": 6,
+    "pollIntervalMs": 30000,
+    "autoCart": false
+  },
+  "campgrounds": [
+    { "campgroundId": "232447", "campgroundName": "Upper Pines Campground", "park": "Yosemite" },
+    { "campgroundId": "232450", "campgroundName": "Lower Pines Campground", "park": "Yosemite" },
+    { "campgroundId": "232449", "campgroundName": "North Pines Campground", "park": "Yosemite" },
+    { "campgroundId": "232451", "campgroundName": "Hodgdon Meadow Campground", "park": "Yosemite" },
+    { "campgroundId": "232452", "campgroundName": "Crane Flat Campground", "park": "Yosemite" },
+    { "campgroundId": "232446", "campgroundName": "Wawona Campground", "park": "Yosemite" },
+    { "campgroundId": "232453", "campgroundName": "Bridalveil Creek Campground", "park": "Yosemite" },
+    { "campgroundId": "232448", "campgroundName": "Tuolumne Meadows Campground", "park": "Yosemite" }
+  ]
 }

--- a/campspot-bot/configLoader.mjs
+++ b/campspot-bot/configLoader.mjs
@@ -1,0 +1,65 @@
+// Config normalizer for the multi-campground campspot-bot.
+//
+// Two on-disk shapes are accepted:
+//   1. Legacy single-campground (everything at the top level).
+//   2. New { shared: {...}, campgrounds: [{...}, ...] } shape.
+//
+// Both normalize to an array of fully-resolved per-campground configs so the
+// rest of the bot doesn't have to care which one was on disk. Per-campground
+// fields override `shared` — useful if e.g. Tuolumne should poll on a longer
+// interval than Upper Pines.
+import { readFileSync } from 'node:fs'
+
+const PER_CAMPGROUND_KEYS = new Set(['campgroundId', 'campgroundName', 'park'])
+
+export function normalizeRawConfig(raw) {
+    if (!raw || typeof raw !== 'object') {
+        throw new Error('config: expected a JSON object')
+    }
+    if (Array.isArray(raw.campgrounds)) {
+        return normalizeMulti(raw)
+    }
+    if (raw.campgroundId) {
+        return normalizeLegacy(raw)
+    }
+    throw new Error('config: missing `campgrounds[]` (or legacy `campgroundId`)')
+}
+
+function normalizeMulti({ shared = {}, campgrounds }) {
+    if (campgrounds.length === 0) {
+        throw new Error('config: campgrounds[] is empty')
+    }
+    return campgrounds.map(cg => {
+        if (!cg.campgroundId) throw new Error('config: campground entry missing campgroundId')
+        // Per-entry overrides win over shared, so Tuolumne can have its own
+        // pollIntervalMs or rangeEndDate without forking the whole config.
+        return { ...shared, ...cg }
+    })
+}
+
+function normalizeLegacy(raw) {
+    const shared = {}
+    const cg = {}
+    for (const [k, v] of Object.entries(raw)) {
+        if (PER_CAMPGROUND_KEYS.has(k)) cg[k] = v
+        else shared[k] = v
+    }
+    return [{ ...shared, ...cg }]
+}
+
+export function loadConfigsFromFile(filePath) {
+    const raw = JSON.parse(readFileSync(filePath, 'utf-8'))
+    return normalizeRawConfig(raw)
+}
+
+// Pick the campground to run by id. Defaults to the first entry if no id
+// is provided so `node campspot-bot.mjs check` still works without args.
+export function selectCampground(configs, campgroundId) {
+    if (!campgroundId) return configs[0]
+    const match = configs.find(c => String(c.campgroundId) === String(campgroundId))
+    if (!match) {
+        const known = configs.map(c => c.campgroundId).join(', ')
+        throw new Error(`config: no campground with id=${campgroundId} (known: ${known})`)
+    }
+    return match
+}

--- a/dashboard/__tests__/dashboardData.test.mjs
+++ b/dashboard/__tests__/dashboardData.test.mjs
@@ -1,0 +1,111 @@
+// Tests for the dashboard data aggregator.
+//
+// Focus: multi-campground campspot scan. The aggregator now lists every
+// `status-*.json` under the state dir and emits one bot view per file.
+// We don't want a half-rolled-out multi-watch deploy to blank out the
+// dashboard, so the legacy `status.json` name is also recognized.
+
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { buildDashboardData } from '../dashboardData.mjs'
+
+function writeState(dir, name, state) {
+    writeFileSync(path.join(dir, name), JSON.stringify(state))
+}
+
+function snapshot(overrides = {}) {
+    return {
+        bot: 'campspot-bot',
+        pid: 0, // 0 → isPidAlive returns false → liveness becomes "dead"; deterministic for tests
+        startedAt: '2026-06-26T07:00:00Z',
+        lastHeartbeat: '2026-06-26T07:00:05Z',
+        mode: 'watch',
+        config: { pollIntervalMs: 30000 },
+        metrics: { cycles: 1, errors: 0 },
+        recentEvents: [],
+        ...overrides,
+    }
+}
+
+describe('buildDashboardData — campspot multi-card', () => {
+    let tmp
+    let savedDir
+    let savedFile
+    let savedLogDir
+
+    beforeEach(() => {
+        tmp = mkdtempSync(path.join(tmpdir(), 'campspot-dash-'))
+        savedDir = process.env.CAMPSPOT_STATE_DIR
+        savedFile = process.env.CAMPSPOT_STATE_FILE
+        savedLogDir = process.env.PERMIT_BOT_LOG_DIR
+        process.env.CAMPSPOT_STATE_DIR = tmp
+        // Point permit-bot away from anything real so its present/absent
+        // result is deterministic and irrelevant to these assertions.
+        process.env.PERMIT_BOT_LOG_DIR = path.join(tmp, 'no-permit-logs-here')
+        delete process.env.CAMPSPOT_STATE_FILE
+    })
+
+    afterEach(() => {
+        restore('CAMPSPOT_STATE_DIR', savedDir)
+        restore('CAMPSPOT_STATE_FILE', savedFile)
+        restore('PERMIT_BOT_LOG_DIR', savedLogDir)
+        rmSync(tmp, { recursive: true, force: true })
+    })
+
+    function restore(key, val) {
+        if (val === undefined) delete process.env[key]
+        else process.env[key] = val
+    }
+
+    test('renders one campspot card per status-*.json in the state dir', () => {
+        writeState(tmp, 'status-232447.json', snapshot({
+            config: { campgroundName: 'Upper Pines Campground', pollIntervalMs: 30000 },
+        }))
+        writeState(tmp, 'status-232450.json', snapshot({
+            config: { campgroundName: 'Lower Pines Campground', pollIntervalMs: 30000 },
+        }))
+
+        const data = buildDashboardData()
+        const campspotCards = data.bots.filter(b => b.bot === 'campspot-bot')
+        expect(campspotCards).toHaveLength(2)
+        const labels = campspotCards.map(c => c.label).sort()
+        expect(labels).toEqual([
+            'campspot-bot (Lower Pines Campground)',
+            'campspot-bot (Upper Pines Campground)',
+        ])
+    })
+
+    test('legacy status.json is still picked up so dashboard-before-bot deploys do not blank', () => {
+        writeState(tmp, 'status.json', snapshot({
+            config: { campgroundName: 'Upper Pines Campground' },
+        }))
+
+        const cards = buildDashboardData().bots.filter(b => b.bot === 'campspot-bot')
+        expect(cards).toHaveLength(1)
+        expect(cards[0].label).toBe('campspot-bot (Upper Pines Campground)')
+    })
+
+    test('no state files → single absent placeholder with run-command hint', () => {
+        const cards = buildDashboardData().bots.filter(b => b.bot === 'campspot-bot')
+        expect(cards).toHaveLength(1)
+        expect(cards[0].liveness).toBe('absent')
+        expect(cards[0].absentReason).toMatch(/--campground=/)
+    })
+
+    test('CAMPSPOT_STATE_FILE (legacy env) still resolves the directory', () => {
+        delete process.env.CAMPSPOT_STATE_DIR
+        process.env.CAMPSPOT_STATE_FILE = path.join(tmp, 'status.json')
+        writeState(tmp, 'status.json', snapshot({
+            config: { campgroundName: 'Upper Pines Campground' },
+        }))
+        const cards = buildDashboardData().bots.filter(b => b.bot === 'campspot-bot')
+        expect(cards).toHaveLength(1)
+    })
+
+    test('label without campgroundName falls back to bare "campspot-bot"', () => {
+        writeState(tmp, 'status-unknown.json', snapshot({ config: {} }))
+        const cards = buildDashboardData().bots.filter(b => b.bot === 'campspot-bot')
+        expect(cards[0].label).toBe('campspot-bot')
+    })
+})

--- a/dashboard/dashboardData.mjs
+++ b/dashboard/dashboardData.mjs
@@ -7,15 +7,31 @@
 // retired 2026-06-22 — campspot-bot's auto-cart flow covers the use case
 // end-to-end now. server.mjs is dashboard-only.
 import path from 'node:path'
+import { readdirSync, existsSync } from 'node:fs'
 import { readBotState, classifyLiveness, isPidAlive } from './botState.mjs'
 import { readPermitBotState } from './permitBotState.mjs'
 
 // Resolved at call time so the dashboard can read campspot-bot's state from a
-// different checkout via CAMPSPOT_STATE_FILE (symmetric to PERMIT_BOT_LOG_DIR).
+// different checkout via CAMPSPOT_STATE_DIR (symmetric to PERMIT_BOT_LOG_DIR).
 // Default is the running server's cwd, which Just Works when the dashboard
-// runs out of the same checkout as the bot.
-function campspotStateFile() {
-    return path.resolve(process.env.CAMPSPOT_STATE_FILE || './campspot-bot/state/status.json')
+// runs out of the same checkout as the bot. CAMPSPOT_STATE_FILE is the legacy
+// single-file knob — still honored so existing deployments don't break, but
+// the multi-campground path is the directory scan.
+function campspotStateDir() {
+    if (process.env.CAMPSPOT_STATE_DIR) return path.resolve(process.env.CAMPSPOT_STATE_DIR)
+    if (process.env.CAMPSPOT_STATE_FILE) return path.dirname(path.resolve(process.env.CAMPSPOT_STATE_FILE))
+    return path.resolve('./campspot-bot/state')
+}
+
+function campspotStateFiles() {
+    const dir = campspotStateDir()
+    if (!existsSync(dir)) return []
+    // Match the per-campground naming the bot writes — `status-<id>.json`.
+    // The legacy `status.json` (single-campground deployments) is included
+    // so dashboards updating ahead of bots don't blank out the card.
+    return readdirSync(dir)
+        .filter(f => /^status(-.+)?\.json$/.test(f))
+        .map(f => path.join(dir, f))
 }
 
 export function buildDashboardData() {
@@ -48,27 +64,39 @@ export function buildDashboardData() {
     }
 
     // --- campspot-bot -------------------------------------------------------
-    const campspot = readBotState(campspotStateFile())
-    const campspotView = campspot ? {
-        ...campspot,
-        label: 'campspot-bot (Upper Pines auto-cart)',
-        // Process-level liveness wins when we have a pid: a dead pid is a
-        // dead bot even if the heartbeat looks recent (process just exited).
-        liveness: isPidAlive(campspot.pid)
-            ? classifyLiveness({
-                lastHeartbeatIso: campspot.lastHeartbeat,
-                pollIntervalMs: campspot.config?.pollIntervalMs,
-            })
-            : 'dead',
-    } : {
-        bot: 'campspot-bot',
-        label: 'campspot-bot (Upper Pines auto-cart)',
-        liveness: 'absent',
-        absentReason: 'not started yet — run `node campspot-bot/campspot-bot.mjs watch --auto-grab`',
+    // One card per running watch — each campground writes its own state file.
+    // If nothing is on disk yet, surface a single "absent" placeholder so the
+    // dashboard still tells the operator what to run.
+    const stateFiles = campspotStateFiles()
+    const campspotViews = stateFiles
+        .map(f => readBotState(f))
+        .filter(Boolean)
+        .map(s => ({
+            ...s,
+            label: campspotLabel(s),
+            liveness: isPidAlive(s.pid)
+                ? classifyLiveness({
+                    lastHeartbeatIso: s.lastHeartbeat,
+                    pollIntervalMs: s.config?.pollIntervalMs,
+                })
+                : 'dead',
+        }))
+    if (campspotViews.length === 0) {
+        campspotViews.push({
+            bot: 'campspot-bot',
+            label: 'campspot-bot',
+            liveness: 'absent',
+            absentReason: 'not started yet — run `node campspot-bot/campspot-bot.mjs watch --campground=<id>`',
+        })
     }
 
     return {
         serverTime: now,
-        bots: [permitView, campspotView],
+        bots: [permitView, ...campspotViews],
     }
+}
+
+function campspotLabel(state) {
+    const name = state.config?.campgroundName
+    return name ? `campspot-bot (${name})` : 'campspot-bot'
 }


### PR DESCRIPTION
## Summary
- Upper Pines is too popular — added the seven other reservable Yosemite campgrounds (Lower/North Pines, Hodgdon Meadow, Crane Flat, Wawona, Bridalveil Creek, Tuolumne Meadows). All IDs verified against the rec.gov facility API.
- Config grew a `{ shared, campgrounds[] }` shape. `shared` covers the targeting window / weekdays / nights / poll interval; each `campgrounds[]` entry layers `{ campgroundId, campgroundName, park }` on top and can override any shared field.
- Bot is single-campground per process; pick the entry with `--campground=ID` (defaults to first). State files split per id (`state/status-<id>.json`) so concurrent watches don't stomp each other.
- Dashboard scans the state dir and emits one card per running bot — `campspot-bot (Upper Pines Campground)`, `campspot-bot (Tuolumne Meadows Campground)`, etc.
- Backward-compat preserved on both ends: legacy single-campground top-level config still loads, and the old `status.json` filename + `CAMPSPOT_STATE_FILE` env still work, so a half-rolled-out deploy doesn't blank the dashboard.

## Test plan
- [x] `npm test` — 270 pass (14 new across two test files)
- [x] `configLoader.test.mjs` covers the new shape, the legacy shape, per-entry overrides, and the error paths (empty list, missing id, unknown id with helpful "known: …" message)
- [x] `dashboardData.test.mjs` covers the dir scan (multi-card), the legacy `status.json` fallback, the no-bots placeholder with run hint, and the `CAMPSPOT_STATE_FILE` env still resolving the dir
- [x] CLI usage banner shows `--campground=ID` on every relevant subcommand
- [ ] Smoke test: spin up two `watch --campground=` processes locally and verify both cards appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)