### PR TITLE
chore: gitignore the whole .claude/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ log/
 data/
 
 
-.claude/settings.local.json
+.claude/
 
 permit-bot/.chromium-profile/
 permit-bot/.chromium-profile-*/


### PR DESCRIPTION
## Summary
- `.gitignore` was only excluding `.claude/settings.local.json`. The rest of `.claude/` (worktree storage at `.claude/worktrees/`, the auto-memory dir at `.claude/projects/`, etc.) showed up as untracked in every `git status`.
- That tripped `deploy.sh`'s clean-tree gate, forcing `ALLOW_DIRTY=1` for routine deploys when the only "dirt" is unrelated tooling state.
- One-line change: ignore the whole `.claude/` directory.

## Test plan
- [x] `git status` from a fresh `git pull` on a checkout with `.claude/` populated → no untracked output
- [x] `./deploy.sh` clean-tree gate would pass without `ALLOW_DIRTY=1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)