### PR TITLE
fix(alienware): xvfb entrypoint, env_file→bind mount, cart verifier regex

### DIFF
--- a/Dockerfile.bots
+++ b/Dockerfile.bots
@@ -40,6 +40,15 @@ RUN npm install --omit=dev
 # compose picks which one to run via `command:`.
 COPY . .
 
+# Entrypoint starts Xvfb + sets DISPLAY before exec'ing the CMD. We
+# don't use `xvfb-run` because its SIGUSR1-based readiness detection
+# hangs under Docker (Xvfb signal never reaches xvfb-run, child never
+# exec'd — verified 2026-06-27 on Alienware). Dashboard service
+# overrides this since it has no chromium.
+COPY with-xvfb /usr/local/bin/with-xvfb
+RUN chmod +x /usr/local/bin/with-xvfb
+ENTRYPOINT ["/usr/local/bin/with-xvfb"]
+
 # No EXPOSE / CMD here — each service in docker-compose-alienware.yml
 # sets its own command. Dashboard container does expose 8787; bots
 # don't expose anything.

--- a/campspot-bot/CampspotCartBot.mjs
+++ b/campspot-bot/CampspotCartBot.mjs
@@ -132,6 +132,23 @@ function humanDate(yyyymmdd) {
 //   'has_items_but_not_target' → cart has SOMETHING but not our site/date
 //   'empty'       → empty cart
 //   'unknown'     → couldn't parse
+// Extracted so the regex can be unit-tested against rec.gov-fixture text
+// without spinning Chromium. Pass 'In' or 'Out'.
+export function checkDateRegex(label) {
+    return new RegExp(`Check[-\\s]*${label}(?:\\s+Date)?:?[\\s\\n]+\\w+,?[\\s\\n]+(\\w+)[\\s\\n]+(\\d+),[\\s\\n]*(\\d{4})`, 'i')
+}
+
+// Returns { checkIn, checkOut } as 'Mon DD, YYYY' (e.g. 'Aug 17, 2026') or null
+// per field. Tolerant of all three label layouts seen on rec.gov.
+export function parseCartCheckDates(cartText) {
+    const ci = cartText.match(checkDateRegex('In'))
+    const co = cartText.match(checkDateRegex('Out'))
+    return {
+        checkIn:  ci ? `${ci[1]} ${ci[2]}, ${ci[3]}` : null,
+        checkOut: co ? `${co[1]} ${co[2]}, ${co[3]}` : null,
+    }
+}
+
 async function verifyCartHold(ctx, { siteNo, startDate, endDate, screenshotPath }) {
     const cartPage = await ctx.newPage()
     let cartShot = null
@@ -146,16 +163,23 @@ async function verifyCartHold(ctx, { siteNo, startDate, endDate, screenshotPath 
         cartText = await cartPage.evaluate(() => document.body.innerText)
 
         // Pull the literal check-in / check-out lines so we can report what we
-        // actually got, not just true/false. rec.gov uses TWO different labels
-        // depending on the view: "Check-In Date: Thu Jun 25, 2026" (full) and
-        // "Check-In: Thu Jul 23, 2026" (compact). The 2026-06-25 cascade lost
-        // a real hold because the regex only matched the full form and the
-        // compact-form cart fell through to `has_items_but_not_target` (no
-        // auto-release, no Discord/ntfy alert, hold expired silently).
-        const ciMatch = cartText.match(/Check-?\s*In(?:\s+Date)?:\s*\w+\s+(\w+)\s+(\d+),\s+(\d{4})/i)
-        const coMatch = cartText.match(/Check-?\s*Out(?:\s+Date)?:\s*\w+\s+(\w+)\s+(\d+),\s+(\d{4})/i)
-        if (ciMatch) observed.checkIn = `${ciMatch[1]} ${ciMatch[2]}, ${ciMatch[3]}`
-        if (coMatch) observed.checkOut = `${coMatch[1]} ${coMatch[2]}, ${coMatch[3]}`
+        // actually got, not just true/false. rec.gov uses THREE different
+        // label layouts seen in the wild:
+        //   1. "Check-In Date: Thu Jun 25, 2026"   (full, /cart legacy)
+        //   2. "Check-In: Thu Jul 23, 2026"        (compact, /cart legacy)
+        //   3. "Check-In\nMon, Aug 17, 2026"       (column header + new
+        //      line, current /cart + /orderdetails — no colon, comma after
+        //      the day-of-week)
+        // 2026-06-25 cascade lost a real hold because we only matched #1.
+        // 2026-06-27 Alienware cart test surfaced #3 and fell through to
+        // `has_items_but_not_target`, which auto-released after timeout —
+        // so a real opening would have been quietly discarded.
+        // Regex tweaks: `[-\s]*` between Check and In/Out (covers hyphen
+        // OR space separator), colon optional, comma after the dow optional
+        // and tolerant of either ", " or " " before the month token.
+        const parsed = parseCartCheckDates(cartText)
+        observed.checkIn = parsed.checkIn
+        observed.checkOut = parsed.checkOut
 
         const startHuman = humanDate(startDate)
         const endHuman = humanDate(endDate)

--- a/campspot-bot/__tests__/parseCartCheckDates.test.mjs
+++ b/campspot-bot/__tests__/parseCartCheckDates.test.mjs
@@ -1,0 +1,47 @@
+import { parseCartCheckDates } from '../CampspotCartBot.mjs'
+
+// rec.gov has rendered the cart/orderdetails check-in line three different
+// ways in the wild. Cover all three so we don't regress when the layout
+// changes again.
+
+describe('parseCartCheckDates', () => {
+    test('layout 1: "Check-In Date:" full label, no comma after dow (2026-06-22)', () => {
+        const text = `Upper Pines\n003, STANDARD NONELECTRIC\nCheck-In Date: Thu Jun 25, 2026\nCheck-Out Date: Fri Jun 26, 2026\n`
+        expect(parseCartCheckDates(text)).toEqual({
+            checkIn: 'Jun 25, 2026',
+            checkOut: 'Jun 26, 2026',
+        })
+    })
+
+    test('layout 2: "Check-In:" compact label (2026-06-25)', () => {
+        const text = `Some preamble\nCheck-In: Thu Jul 23, 2026\nCheck-Out: Sat Jul 25, 2026\n`
+        expect(parseCartCheckDates(text)).toEqual({
+            checkIn: 'Jul 23, 2026',
+            checkOut: 'Jul 25, 2026',
+        })
+    })
+
+    test('layout 3: column-header on its own line, comma after dow (2026-06-27, Wawona alienware test)', () => {
+        const text = `040, B | STANDARD NONELECTRIC\nCheck-In\nMon, Aug 17, 2026\nCheck Out\nTue, Aug 18, 2026\nPrimary Occupant`
+        expect(parseCartCheckDates(text)).toEqual({
+            checkIn: 'Aug 17, 2026',
+            checkOut: 'Aug 18, 2026',
+        })
+    })
+
+    test('returns null fields when both labels absent (empty cart)', () => {
+        const text = 'Your cart is empty! Looks like your cart is empty.'
+        expect(parseCartCheckDates(text)).toEqual({
+            checkIn: null,
+            checkOut: null,
+        })
+    })
+
+    test('partial: check-in present but check-out missing', () => {
+        const text = 'Check-In\nMon, Aug 17, 2026\nsome other stuff but no check out'
+        expect(parseCartCheckDates(text)).toEqual({
+            checkIn: 'Aug 17, 2026',
+            checkOut: null,
+        })
+    })
+})

--- a/docker-compose-alienware.observe.yml
+++ b/docker-compose-alienware.observe.yml
@@ -12,13 +12,18 @@
 # Drop (flip to authoritative):
 #     sudo docker compose -f docker-compose-alienware.yml up -d
 #
+# Only the two auto-grab services need overriding: campspot-upper-pines
+# (drops `--auto-grab`) and permit-bot (uses `watch` instead of
+# `watch-auto`). The other 7 campspot-* services are notify-only by
+# default in the base compose, so they need no observe override.
+#
 # Caveat: in observe mode the permit-bot uses `watch` instead of
 # `watch-auto`. `watch` does NOT emit JSONL session logs (only
 # watch-auto does), so the dashboard's permit-bot panel will show
 # `liveness: absent, absentReason: "no session log"`. Expected.
 
 services:
-  campspot-bot:
-    command: ["node", "campspot-bot/campspot-bot.mjs", "watch"]
+  campspot-upper-pines:
+    command: ["node", "campspot-bot/campspot-bot.mjs", "watch", "--campground=232447"]
   permit-bot:
     command: ["node", "permit-bot/permit-bot.mjs", "watch"]

--- a/docker-compose-alienware.observe.yml
+++ b/docker-compose-alienware.observe.yml
@@ -1,0 +1,24 @@
+# Burn-in / observe-mode override for the Alienware stack.
+# Use during the parallel-to-Mac validation window so the Alienware bots
+# poll-and-notify but DO NOT compete with the Mac bot for real cart holds
+# or permit grabs. Once we've seen N hours of clean cycle parity, stop
+# using this override and the base compose's `watch --auto-grab` /
+# `watch-auto` commands take over.
+#
+# Apply:
+#     sudo docker compose -f docker-compose-alienware.yml \
+#                         -f docker-compose-alienware.observe.yml up -d
+#
+# Drop (flip to authoritative):
+#     sudo docker compose -f docker-compose-alienware.yml up -d
+#
+# Caveat: in observe mode the permit-bot uses `watch` instead of
+# `watch-auto`. `watch` does NOT emit JSONL session logs (only
+# watch-auto does), so the dashboard's permit-bot panel will show
+# `liveness: absent, absentReason: "no session log"`. Expected.
+
+services:
+  campspot-bot:
+    command: ["node", "campspot-bot/campspot-bot.mjs", "watch"]
+  permit-bot:
+    command: ["node", "permit-bot/permit-bot.mjs", "watch"]

--- a/docker-compose-alienware.yml
+++ b/docker-compose-alienware.yml
@@ -1,18 +1,21 @@
-# Burn-in stack for Alienware (192.168.68.90).
-#
-# Parallel to the Mac deployment: the Mac bots stay running and authoritative
-# until rec.gov anti-bot behavior on Linux-in-Docker is verified to be
-# indistinguishable. Run this stack in DRY-RUN first (see TODO below) so the
-# campspot-bot here just *observes* and reports — no real cart attempts —
-# while the Mac bot continues to actually race.
+# Stack for Alienware (192.168.68.90).
 #
 # Deploy pattern (matches every other compose in homelab/):
-#     tar czf - Dockerfile.bots docker-compose-alienware.yml package*.json \
-#         dashboard campspot-bot permit-bot server.mjs .env \
-#       | ssh fredcorn@192.168.68.90 \
-#           'mkdir -p /opt/campspot-checker && tar xzf - -C /opt/campspot-checker'
+#     git archive --format=tar HEAD | ssh fredcorn@192.168.68.90 \
+#         'mkdir -p /home/fredcorn/campspot-checker && tar xf - -C /home/fredcorn/campspot-checker'
+#     scp -O .env fredcorn@192.168.68.90:/home/fredcorn/campspot-checker/.env
+#     ssh fredcorn@192.168.68.90 'chmod 600 /home/fredcorn/campspot-checker/.env'
 #     ssh fredcorn@192.168.68.90 \
-#       'cd /opt/campspot-checker && sudo docker compose -f docker-compose-alienware.yml up -d --build'
+#       'cd /home/fredcorn/campspot-checker && sudo docker compose -f docker-compose-alienware.yml up -d --build'
+#
+# For BURN-IN mode (observe-only, no real cart attempts) layer the override:
+#     sudo docker compose -f docker-compose-alienware.yml \
+#                         -f docker-compose-alienware.observe.yml up -d
+#
+# First-time bootstrap — log into rec.gov to seed chromium-profile volume:
+#     sudo docker compose -f docker-compose-alienware.yml \
+#       run --rm --entrypoint "" permit-bot \
+#       sh -c 'Xvfb :99 & sleep 1; DISPLAY=:99 node permit-bot/permit-bot.mjs login'
 #
 # Dashboard URL when up: http://192.168.68.90:8787/bots
 #
@@ -20,6 +23,12 @@
 # managed by Docker and survive `docker compose down`. The chromium-profile
 # volume MUST persist across recreates or rec.gov asks for a fresh login
 # every restart.
+#
+# .env is bind-mounted (not `env_file:`) because env_file passes values
+# verbatim — including surrounding quotes and trailing comments — which
+# corrupts URLs (verified 2026-06-27: Discord webhook failed with
+# "Invalid URL" until we mounted .env so dotenv.config() in-bot could
+# parse it the same way it does on the Mac).
 
 services:
   campspot-bot:
@@ -30,16 +39,9 @@ services:
     container_name: campspot-bot
     restart: unless-stopped
     shm_size: 1gb  # Chromium chokes on Docker's default 64MB /dev/shm
-    env_file:
-      - .env
-    # xvfb-run gives Chromium a virtual $DISPLAY so headless=false (which the
-    # cart bot hard-codes for rec.gov fingerprinting reasons) doesn't crash.
-    # TODO during burn-in: replace `watch --auto-grab` with `check` or a new
-    # `watch --dry-run` flag so this container observes without competing
-    # with the Mac bot for real cart holds. Cut over only when fingerprint
-    # behavior matches.
-    command: ["xvfb-run", "--auto-servernum", "node", "campspot-bot/campspot-bot.mjs", "watch", "--auto-grab"]
+    command: ["node", "campspot-bot/campspot-bot.mjs", "watch", "--auto-grab"]
     volumes:
+      - ./.env:/app/.env:ro                                # dotenv reads this
       - bot-state:/app/campspot-bot/state                  # dashboard mounts ro
       - chromium-profile:/app/permit-bot/.chromium-profile # shared with permit-bot
       - campspot-screenshots:/app/campspot-bot/.screenshots
@@ -52,10 +54,9 @@ services:
     container_name: permit-bot
     restart: unless-stopped
     shm_size: 1gb
-    env_file:
-      - .env
-    command: ["xvfb-run", "--auto-servernum", "node", "permit-bot/permit-bot.mjs", "watch-auto"]
+    command: ["node", "permit-bot/permit-bot.mjs", "watch-auto"]
     volumes:
+      - ./.env:/app/.env:ro
       - permit-logs:/app/permit-bot/logs                   # dashboard mounts ro
       - chromium-profile:/app/permit-bot/.chromium-profile # shared with campspot-bot
       - permit-screenshots:/app/permit-bot/.screenshots
@@ -70,18 +71,20 @@ services:
     restart: unless-stopped
     ports:
       - "8787:8787"
-    env_file:
-      - .env
     environment:
       - PORT=8787
-      # These point dashboardData.mjs at the volumes the bots write to.
-      # Without them dashboard falls back to ./campspot-bot/state/status.json
+      # Point dashboardData.mjs at the volumes the bots write to.
+      # Without these the dashboard falls back to ./campspot-bot/state/status.json
       # and ./permit-bot/logs in its own container — both empty — and renders
       # a stale-looking but technically-correct "no data" page.
       - CAMPSPOT_STATE_FILE=/app/campspot-bot/state/status.json
       - PERMIT_BOT_LOG_DIR=/app/permit-bot/logs
-    command: ["node", "server.mjs"]
+    # Override the with-xvfb ENTRYPOINT — dashboard has no chromium so
+    # starting Xvfb here is dead weight.
+    entrypoint: ["node"]
+    command: ["server.mjs"]
     volumes:
+      - ./.env:/app/.env:ro
       - bot-state:/app/campspot-bot/state:ro
       - permit-logs:/app/permit-bot/logs:ro
 

--- a/docker-compose-alienware.yml
+++ b/docker-compose-alienware.yml
@@ -8,7 +8,8 @@
 #     ssh fredcorn@192.168.68.90 \
 #       'cd /home/fredcorn/campspot-checker && sudo docker compose -f docker-compose-alienware.yml up -d --build'
 #
-# For BURN-IN mode (observe-only, no real cart attempts) layer the override:
+# For BURN-IN mode (observe-only, no real cart attempts or permit grabs)
+# layer the override:
 #     sudo docker compose -f docker-compose-alienware.yml \
 #                         -f docker-compose-alienware.observe.yml up -d
 #
@@ -29,22 +30,76 @@
 # corrupts URLs (verified 2026-06-27: Discord webhook failed with
 # "Invalid URL" until we mounted .env so dotenv.config() in-bot could
 # parse it the same way it does on the Mac).
+#
+# MULTI-CAMPGROUND HUNTING:
+# One campspot-bot service per Yosemite campground. Only Upper Pines has
+# `--auto-grab` enabled — the others are notify-only because Chromium
+# can't share a user-data-dir across processes (one process holds the
+# profile lock at a time, verified 2026-06-27 during login bootstrap).
+# Notify-only bots poll the API every 30s and push Discord/ntfy when
+# openings appear; the human races those manually. Upper Pines is the
+# only one with enough cancellation traffic to justify the auto-grab
+# warm-window cost.
+
+x-campspot-base: &campspot-base
+  build:
+    context: .
+    dockerfile: Dockerfile.bots
+  image: campspot-checker:bots
+  restart: unless-stopped
+  shm_size: 1gb  # Chromium chokes on Docker's default 64MB /dev/shm
+  volumes:
+    - ./.env:/app/.env:ro                                # dotenv reads this
+    - bot-state:/app/campspot-bot/state                  # dashboard mounts ro
+    - chromium-profile:/app/permit-bot/.chromium-profile # only Upper Pines actually uses this
+    - campspot-screenshots:/app/campspot-bot/.screenshots
 
 services:
-  campspot-bot:
-    build:
-      context: .
-      dockerfile: Dockerfile.bots
-    image: campspot-checker:bots
-    container_name: campspot-bot
-    restart: unless-stopped
-    shm_size: 1gb  # Chromium chokes on Docker's default 64MB /dev/shm
-    command: ["node", "campspot-bot/campspot-bot.mjs", "watch", "--auto-grab"]
-    volumes:
-      - ./.env:/app/.env:ro                                # dotenv reads this
-      - bot-state:/app/campspot-bot/state                  # dashboard mounts ro
-      - chromium-profile:/app/permit-bot/.chromium-profile # shared with permit-bot
-      - campspot-screenshots:/app/campspot-bot/.screenshots
+  # Upper Pines: auto-grab on (warm chromium, races cancellations).
+  # The only campspot-bot that holds the chromium-profile lock.
+  campspot-upper-pines:
+    <<: *campspot-base
+    container_name: campspot-upper-pines
+    command: ["node", "campspot-bot/campspot-bot.mjs", "watch", "--auto-grab", "--campground=232447"]
+
+  # Notify-only siblings: no --auto-grab → no warm chromium → no profile
+  # lock conflict with Upper Pines. Each writes its own status file
+  # (status-{campgroundId}.json) into the shared bot-state volume, which
+  # the dashboard renders as a separate panel.
+  campspot-lower-pines:
+    <<: *campspot-base
+    container_name: campspot-lower-pines
+    command: ["node", "campspot-bot/campspot-bot.mjs", "watch", "--campground=232450"]
+
+  campspot-north-pines:
+    <<: *campspot-base
+    container_name: campspot-north-pines
+    command: ["node", "campspot-bot/campspot-bot.mjs", "watch", "--campground=232449"]
+
+  campspot-hodgdon-meadow:
+    <<: *campspot-base
+    container_name: campspot-hodgdon-meadow
+    command: ["node", "campspot-bot/campspot-bot.mjs", "watch", "--campground=232451"]
+
+  campspot-crane-flat:
+    <<: *campspot-base
+    container_name: campspot-crane-flat
+    command: ["node", "campspot-bot/campspot-bot.mjs", "watch", "--campground=232452"]
+
+  campspot-wawona:
+    <<: *campspot-base
+    container_name: campspot-wawona
+    command: ["node", "campspot-bot/campspot-bot.mjs", "watch", "--campground=232446"]
+
+  campspot-bridalveil-creek:
+    <<: *campspot-base
+    container_name: campspot-bridalveil-creek
+    command: ["node", "campspot-bot/campspot-bot.mjs", "watch", "--campground=232453"]
+
+  campspot-tuolumne-meadows:
+    <<: *campspot-base
+    container_name: campspot-tuolumne-meadows
+    command: ["node", "campspot-bot/campspot-bot.mjs", "watch", "--campground=232448"]
 
   permit-bot:
     build:
@@ -58,7 +113,7 @@ services:
     volumes:
       - ./.env:/app/.env:ro
       - permit-logs:/app/permit-bot/logs                   # dashboard mounts ro
-      - chromium-profile:/app/permit-bot/.chromium-profile # shared with campspot-bot
+      - chromium-profile:/app/permit-bot/.chromium-profile # shared with campspot-upper-pines
       - permit-screenshots:/app/permit-bot/.screenshots
       - permit-traces:/app/permit-bot/.traces
 
@@ -73,11 +128,11 @@ services:
       - "8787:8787"
     environment:
       - PORT=8787
-      # Point dashboardData.mjs at the volumes the bots write to.
-      # Without these the dashboard falls back to ./campspot-bot/state/status.json
-      # and ./permit-bot/logs in its own container — both empty — and renders
-      # a stale-looking but technically-correct "no data" page.
-      - CAMPSPOT_STATE_FILE=/app/campspot-bot/state/status.json
+      # CAMPSPOT_STATE_FILE points at one file in the state dir; the
+      # dashboard derives the dir from it via path.dirname() and globs
+      # for status-*.json — so we get one panel per campground bot
+      # automatically. PERMIT_BOT_LOG_DIR is the standard log glob root.
+      - CAMPSPOT_STATE_FILE=/app/campspot-bot/state/status-232447.json
       - PERMIT_BOT_LOG_DIR=/app/permit-bot/logs
     # Override the with-xvfb ENTRYPOINT — dashboard has no chromium so
     # starting Xvfb here is dead weight.

--- a/with-xvfb
+++ b/with-xvfb
@@ -1,0 +1,18 @@
+#!/bin/sh
+# Entrypoint for the bot containers: start Xvfb on :99, export DISPLAY,
+# then exec the container CMD. Replaces `xvfb-run` because xvfb-run
+# relies on Xvfb's SIGUSR1 readiness signal which is unreliable under
+# Docker — process tree showed Xvfb alive but xvfb-run never exec'd
+# its child (verified 2026-06-27 on Alienware).
+#
+# A short fixed sleep is enough: Xvfb is local-IPC, ready in ~50ms.
+# Polling /tmp/.X11-unix/X99 would be tighter but adds complexity for
+# zero observable benefit.
+#
+# Dashboard service overrides this via `entrypoint:` in compose since
+# it doesn't need a display.
+set -e
+Xvfb :99 -screen 0 1280x1024x24 -nolisten tcp -ac &
+export DISPLAY=:99
+sleep 1
+exec "$@"


### PR DESCRIPTION
## Summary

Three real bugs from the **2026-06-27 end-to-end test** plus **multi-campground hunting** for all 8 Yosemite campgrounds.

### 1. xvfb-run → `with-xvfb` ENTRYPOINT
`xvfb-run` relies on Xvfb's SIGUSR1 readiness signal, which doesn't reliably reach the wrapper under Docker. Process tree confirmed Xvfb alive but the node child never spawned. New `with-xvfb` script just `Xvfb :99 &`, sets `DISPLAY`, sleeps 1s, execs CMD. Dashboard overrides entrypoint to skip Xvfb.

### 2. compose `env_file:` → bind-mount `.env`
Docker's `env_file:` passes raw values verbatim (no quote-stripping, no comment-stripping). That corrupted the Discord webhook URL → `WARN Discord push failed: Invalid URL` on every notification. Bind-mounting `./.env:/app/.env:ro` lets the bot's existing `dotenv.config()` parse it the same way it does on Mac.

### 3. Cart verifier handles a 3rd rec.gov layout
The `/camping/reservations/orderdetails` and current `/cart` pages render:
```
Check-In
Mon, Aug 17, 2026
Check Out
Tue, Aug 18, 2026
```
Column-header on its own line, comma after the day-of-week, no colon. Previous regex required colon + no comma, so a real hold parsed as `has_items_but_not_target` → caller auto-released. Extracted to `parseCartCheckDates()` + jest fixture tests covering all three layouts.

### 4. Multi-campground watch (8 Yosemite campgrounds)
One campspot-bot container per campground, fanning out from the original single-campground stack:

| Campground | Mode |
|---|---|
| Upper Pines | **auto-grab** |
| Lower Pines, North Pines | notify-only |
| Hodgdon Meadow, Crane Flat | notify-only |
| Wawona, Bridalveil Creek | notify-only |
| Tuolumne Meadows | notify-only |

**Only Upper Pines is auto-grab** because Chromium can't share a user-data-dir across processes — one bot holds the rec.gov-logged-in profile lock at a time. Upper Pines is the only campground with enough cancellation traffic to justify the warm-window cost; the alternates are responsive enough for manual phone-cart from a Discord/ntfy alert (~30s). Adding more auto-grab campgrounds would need more rec.gov accounts (one chromium profile per account).

Dashboard auto-renders one panel per campground via the existing `status-{campgroundId}.json` globbing (added in PR #32). YAML anchor `x-campspot-base` keeps the 8 services DRY.

### Also
- Ship `docker-compose-alienware.observe.yml` as a tracked override (previously lived only on Alienware). Used during burn-in.
- Updated header comments to document the new deploy + bootstrap pattern.

## Test plan
- [x] `npm test --testPathIgnorePatterns=availability-checker` — 198 passing (5 new `parseCartCheckDates` tests). The 36 legacy `availability-checker` failures are a pre-existing local `better-sqlite3` Node-version mismatch; CI doesn't hit it (prior run on this PR was green).
- [x] `docker compose -f docker-compose-alienware.yml -f docker-compose-alienware.observe.yml config` lints clean
- [ ] After merge: redeploy to Alienware, confirm 10 containers up (8 campspot-* + permit-bot + dashboard), confirm dashboard renders 8 campground panels

🤖 Generated with [Claude Code](https://claude.com/claude-code)