### PR TITLE
feat(permit-bot): Little Lakes Valley (Inyo) cancellation watcher

### DIFF
--- a/docker-compose-alienware.yml
+++ b/docker-compose-alienware.yml
@@ -117,6 +117,24 @@ services:
       - permit-screenshots:/app/permit-bot/.screenshots
       - permit-traces:/app/permit-bot/.traces
 
+  # Inyo NF Little Lakes Valley walk-up cancellation watcher. Pure HTTP poll —
+  # no chromium, no cart automation. `watch` pings ntfy/Discord on any
+  # transition from suppressed/zero → remaining > 0. Targets 2026-07-03
+  # (party of 3) per permit-bot/config.little-lakes-valley.json.
+  permit-bot-llv:
+    build:
+      context: .
+      dockerfile: Dockerfile.bots
+    image: campspot-checker:bots
+    container_name: permit-bot-llv
+    restart: unless-stopped
+    command: [
+      "node", "permit-bot/permit-bot.mjs", "watch",
+      "--config=permit-bot/config.little-lakes-valley.json"
+    ]
+    volumes:
+      - ./.env:/app/.env:ro
+
   dashboard:
     build:
       context: .

--- a/permit-bot/config.little-lakes-valley.json
+++ b/permit-bot/config.little-lakes-valley.json
@@ -1,0 +1,20 @@
+{
+  "permitId": "233262",
+  "permitName": "Inyo National Forest Wilderness Permits — Little Lakes Valley",
+  "targets": [
+    {
+      "divisionId": "451",
+      "name": "Little Lakes Valley",
+      "nameTokens": ["Little Lakes Valley"]
+    }
+  ],
+  "targetDates": ["2026-07-03"],
+  "_targetDates_comment": "Friday 7/3/2026 walk-up start for the long weekend, party of 3. Inyo walk-up permits release 14 days ahead at 7am PT; 7/3 released on 2026-06-19 and is currently sold out (cell suppressed). Monitor catches cancellations.",
+  "partySize": 3,
+  "pollIntervalMs": 30000,
+  "burstWindow": {
+    "startIso": null,
+    "endIso": null,
+    "burstIntervalMs": 30000
+  }
+}

--- a/permit-bot/permit-bot.mjs
+++ b/permit-bot/permit-bot.mjs
@@ -24,9 +24,12 @@ const log = {
     error: (msg) => console.error(`[${new Date().toISOString()}] ERR  ${msg}`),
 }
 
+// Default config path; can be overridden by --config=<path> at the CLI.
+// Set once at dispatcher startup so every cmdX call sees the same value.
+let configPath = path.resolve('./permit-bot/config.json')
+
 function loadConfig() {
-    const p = path.resolve('./permit-bot/config.json')
-    const raw = readFileSync(p, 'utf-8')
+    const raw = readFileSync(configPath, 'utf-8')
     return JSON.parse(raw)
 }
 
@@ -1209,6 +1212,10 @@ const kv = Object.fromEntries(
 
 ;(async () => {
     try {
+        if (kv.config) {
+            configPath = path.resolve(kv.config)
+            log.info(`Using config: ${configPath}`)
+        }
         const accountIndex = kv.account ? Number(kv.account) : 1
         switch (subcommand) {
             case 'login':
@@ -1311,6 +1318,10 @@ const kv = Object.fromEntries(
             }
             default:
                 console.log(`Usage:
+  Any subcommand accepts --config=<path> to point at an alternate permit config
+  (default: permit-bot/config.json). Used to monitor permits beyond LYV (e.g.
+  permit-bot/config.little-lakes-valley.json).
+
   node permit-bot/permit-bot.mjs login [--account=N]              # interactive rec.gov login (default account=1)
   node permit-bot/permit-bot.mjs check-session [--account=N]      # verify saved login still works
   node permit-bot/permit-bot.mjs probe                             # one-shot availability snapshot


### PR DESCRIPTION
## Summary

- New `--config=<path>` flag on `permit-bot.mjs` so one binary can watch any rec.gov permit, not just LYV. Default path unchanged.
- New `permit-bot/config.little-lakes-valley.json`: permit `233262`, division `451`, single static target date `2026-07-03`, party 3, 30s poll.
- New `permit-bot-llv` sibling service in `docker-compose-alienware.yml`: HTTP-only `watch`, no chromium, no cart automation.

## Why

Targeting **Friday 7/3/2026** (Little Lakes Valley, Inyo NF) for a long-weekend overnight, party of 3. The trailhead is walk-up only — 15 spots released `6/19 7am PT` for that date and are now sold out (API suppresses the cell entirely). This watcher catches the moment a cancellation flips it back to `remaining > 0` and pings Discord/ntfy.

LYV watcher is untouched; default config behavior is identical to before.

## Test plan
- [x] `node permit-bot/permit-bot.mjs probe` → still shows HI/GP rows (LYV default unaffected).
- [x] `node permit-bot/permit-bot.mjs probe --config=permit-bot/config.little-lakes-valley.json` → shows `2026-07-03 Little Lakes Valley —/—` (cell suppressed = sold out).
- [x] `npm test` → 11 suites, 125 tests pass.
- [ ] After merge: rebuild Alienware stack to spin up `permit-bot-llv`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)