### PR TITLE
fix(campspot-bot): cut 429s by slowing notify-only polls to 180s

### DIFF
--- a/campspot-bot/config.json
+++ b/campspot-bot/config.json
@@ -12,12 +12,12 @@
   },
   "campgrounds": [
     { "campgroundId": "232447", "campgroundName": "Upper Pines Campground", "park": "Yosemite" },
-    { "campgroundId": "232450", "campgroundName": "Lower Pines Campground", "park": "Yosemite" },
-    { "campgroundId": "232449", "campgroundName": "North Pines Campground", "park": "Yosemite" },
-    { "campgroundId": "232451", "campgroundName": "Hodgdon Meadow Campground", "park": "Yosemite" },
-    { "campgroundId": "232452", "campgroundName": "Crane Flat Campground", "park": "Yosemite" },
-    { "campgroundId": "232446", "campgroundName": "Wawona Campground", "park": "Yosemite" },
-    { "campgroundId": "232453", "campgroundName": "Bridalveil Creek Campground", "park": "Yosemite" },
-    { "campgroundId": "232448", "campgroundName": "Tuolumne Meadows Campground", "park": "Yosemite" }
+    { "campgroundId": "232450", "campgroundName": "Lower Pines Campground", "park": "Yosemite", "pollIntervalMs": 180000 },
+    { "campgroundId": "232449", "campgroundName": "North Pines Campground", "park": "Yosemite", "pollIntervalMs": 180000 },
+    { "campgroundId": "232451", "campgroundName": "Hodgdon Meadow Campground", "park": "Yosemite", "pollIntervalMs": 180000 },
+    { "campgroundId": "232452", "campgroundName": "Crane Flat Campground", "park": "Yosemite", "pollIntervalMs": 180000 },
+    { "campgroundId": "232446", "campgroundName": "Wawona Campground", "park": "Yosemite", "pollIntervalMs": 180000 },
+    { "campgroundId": "232453", "campgroundName": "Bridalveil Creek Campground", "park": "Yosemite", "pollIntervalMs": 180000 },
+    { "campgroundId": "232448", "campgroundName": "Tuolumne Meadows Campground", "park": "Yosemite", "pollIntervalMs": 180000 }
   ]
 }


### PR DESCRIPTION
## Summary
After PR #35 landed the 8-campground stack on Alienware, the user started getting frequent **429s from rec.gov**.

Math: 8 bots × 3 month-payloads per cycle / 30s = 48/min just from campspot, plus permit-bot's ~40/min. Sustained ~88/min from one IP tripped rec.gov's per-IP limit.

Fix: per-campground `pollIntervalMs` override (already supported by `configLoader.normalizeMulti`, PR #32 — no code change).
- **Upper Pines: 30s** (race-critical, only auto-grab target)
- **Other 7: 180s** (notify-only — human races manually from Discord ping; 3 min is fast enough for non-competitive cancellations)

New rate: 6/min (Upper Pines) + 7/min (others combined) + 40/min (permit) ≈ 53/min. Comfortable under typical 60–90/min limits.

## Test plan
- [x] No code change; verified `configLoader.mjs:35` merges per-campground overrides on top of `shared`
- [ ] After redeploy: tail logs for ~10 min, confirm no `WARN HTTP 429` lines
- [ ] Confirm Upper Pines log shows `cycle N` every ~30s, others every ~180s

🤖 Generated with [Claude Code](https://claude.com/claude-code)