### PR TITLE
chore(config): narrow Upper Pines to trip dates only (2026-09-24→09-28)

### DIFF
--- a/campspot-bot/config.json
+++ b/campspot-bot/config.json
@@ -11,7 +11,14 @@
     "autoCart": false
   },
   "campgrounds": [
-    { "campgroundId": "232447", "campgroundName": "Upper Pines Campground", "park": "Yosemite" },
+    {
+      "campgroundId": "232447",
+      "campgroundName": "Upper Pines Campground",
+      "park": "Yosemite",
+      "_note": "user already holds site 233 for 2026-09-24→09-28 (booked 2026-07-01). Narrowed range = only alert on 2nd sites for the same trip dates so extra friends can join. Auto-grab pause (PR #39) will cap accidental double-book at 1.",
+      "rangeStartDate": "2026-09-24",
+      "rangeEndDate": "2026-09-28"
+    },
     { "campgroundId": "232450", "campgroundName": "Lower Pines Campground", "park": "Yosemite", "pollIntervalMs": 180000 },
     { "campgroundId": "232449", "campgroundName": "North Pines Campground", "park": "Yosemite", "pollIntervalMs": 180000 },
     { "campgroundId": "232451", "campgroundName": "Hodgdon Meadow Campground", "park": "Yosemite", "pollIntervalMs": 180000 },


### PR DESCRIPTION
## Summary
User successfully booked Upper Pines site 233 for **2026-09-24 → 09-28** on 2026-07-01. Bot was still hunting the whole 2026-06-22 → 09-30 window with `--auto-grab` on, which risks accidentally grabbing an unrelated trip on the same account.

Per-campground override narrows Upper Pines to just those 5 dates so **any hit = candidate second site for the SAME trip** (extra friends joining). Alienware Lower Pines / North Pines unchanged — they're notify-only and keep the full range so a bigger site or better alternative anywhere in Yosemite still surfaces.

Interacts with PR #39: even if a match on the narrow window fires, the new 24h auto-pause caps runaway at 1 attempt.

## Test plan
- [x] JSON parses (validated)
- [ ] Mac + Alienware restart: confirm Upper Pines `watch:` log line shows `window=2026-09-24..2026-09-28`, other bots unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)