### PR TITLE
feat(ntfy): optional Bearer token for self-hosted ntfy servers

### DIFF
--- a/campspot-bot/campspot-bot.mjs
+++ b/campspot-bot/campspot-bot.mjs
@@ -43,6 +43,10 @@ const DISCORD_WEBHOOK_URL = process.env.CAMPSPOT_DISCORD_WEBHOOK_URL
     || process.env.WEBHOOK_URL
     || null
 const NTFY_TOPIC_URL = process.env.NTFY_TOPIC_URL || null
+// Self-hosted ntfy (auth-default-access: deny-all) requires a per-producer
+// Bearer token. Public ntfy.sh topics ignore it. Leaving unset keeps the
+// public-topic path working, so this is a strict superset of the old behavior.
+const NTFY_AUTH_TOKEN = process.env.NTFY_AUTH_TOKEN || null
 
 function pickConfig(campgroundIdArg) {
     const configs = loadConfigsFromFile(CONFIG_FILE)
@@ -87,6 +91,7 @@ async function pushNtfy(title, message, opts = {}) {
             'Priority': opts.priority || '5',
             'Tags': opts.tags || 'tent,mountain',
         }
+        if (NTFY_AUTH_TOKEN) headers['Authorization'] = `Bearer ${NTFY_AUTH_TOKEN}`
         if (opts.click) headers['Click'] = opts.click
         if (opts.actions?.length) {
             headers['Actions'] = opts.actions.map(a =>

--- a/permit-bot/permit-bot.mjs
+++ b/permit-bot/permit-bot.mjs
@@ -33,6 +33,10 @@ function loadConfig() {
 // ntfy topic from existing .env; same channel as the campground bot so the user
 // only has one subscription to manage.
 const NTFY_TOPIC_URL = process.env.NTFY_TOPIC_URL || null
+// Self-hosted ntfy (auth-default-access: deny-all) requires a per-producer
+// Bearer token. Public ntfy.sh topics ignore it — leaving unset keeps the
+// public-topic path working, so this is a strict superset of old behavior.
+const NTFY_AUTH_TOKEN = process.env.NTFY_AUTH_TOKEN || null
 // Permit-bot has its own Discord channel so cart-hold confirmations don't
 // drown out the campspot-checker's campground alerts. Falls back to the
 // campspot WEBHOOK_URL if no permit-specific one is set.
@@ -148,6 +152,7 @@ async function pushNtfy(title, message, opts = {}) {
             'Priority': opts.priority || '5',
             'Tags': opts.tags || 'mountain,bell',
         }
+        if (NTFY_AUTH_TOKEN) headers['Authorization'] = `Bearer ${NTFY_AUTH_TOKEN}`
         if (opts.click) headers['Click'] = opts.click
         if (opts.actions?.length) {
             // ntfy "Actions" header is comma-separated, ASCII-only labels.


### PR DESCRIPTION
## Summary
Prep for moving both bots off the public \`ntfy.sh/alienware-f20d0e8e20ccaa5c\` topic (which has no auth — topic name = password) onto the homelab self-hosted ntfy at \`https://ntfy.home.yuweiliang.com\` (auth-default-access: deny-all, per-producer write-only tokens).

Adds \`NTFY_AUTH_TOKEN\` env var support in both \`campspot-bot\` and \`permit-bot\`. When set, each push includes \`Authorization: Bearer <token>\`. When unset, the header is omitted and public ntfy.sh topics still work — strict superset of the prior behavior, no breaking change.

## Test plan
- [x] \`npm test --testPathIgnorePatterns=availability-checker\` — 214 passing
- [ ] After merge + deploy: create \`campspot\` producer on Alienware ntfy, update .env on Mac + Alienware with new NTFY_TOPIC_URL + NTFY_AUTH_TOKEN, restart bots, verify a real push lands on the iPhone

🤖 Generated with [Claude Code](https://claude.com/claude-code)