### PR TITLE
feat(notify): Telegram fan-out alongside Discord (opt-in via env)

### DIFF
--- a/campspot-bot/campspot-bot.mjs
+++ b/campspot-bot/campspot-bot.mjs
@@ -47,13 +47,87 @@ const NTFY_TOPIC_URL = process.env.NTFY_TOPIC_URL || null
 // Bearer token. Public ntfy.sh topics ignore it. Leaving unset keeps the
 // public-topic path working, so this is a strict superset of the old behavior.
 const NTFY_AUTH_TOKEN = process.env.NTFY_AUTH_TOKEN || null
+// Telegram bot (opt-in via .env). Bot token from @BotFather, chat_id from
+// the getUpdates dance in the setup doc. Both required to enable — either
+// missing = skip Telegram silently.
+const TELEGRAM_BOT_TOKEN = process.env.TELEGRAM_BOT_TOKEN || null
+const TELEGRAM_CHAT_ID = process.env.TELEGRAM_CHAT_ID || null
 
 function pickConfig(campgroundIdArg) {
     const configs = loadConfigsFromFile(CONFIG_FILE)
     return selectCampground(configs, campgroundIdArg)
 }
 
+// Convert Discord-flavored **bold** to Telegram HTML <b>bold</b>. Escape
+// <, >, & first so user content can't inject markup.
+function telegramFormatText(text) {
+    const escaped = text
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+    return escaped.replace(/\*\*([^*\n]+)\*\*/g, '<b>$1</b>')
+}
+
+async function pushTelegram(text, screenshotPath = null) {
+    if (!TELEGRAM_BOT_TOKEN || !TELEGRAM_CHAT_ID) return { ok: false, status: 0, skipped: true }
+    try {
+        const html = telegramFormatText(text)
+        if (screenshotPath) {
+            // sendPhoto — caption max 1024 chars, so overflow spills into
+            // a follow-up sendMessage.
+            const form = new FormData()
+            form.append('chat_id', TELEGRAM_CHAT_ID)
+            form.append('parse_mode', 'HTML')
+            form.append('caption', html.slice(0, 1024))
+            form.append('photo', createReadStream(screenshotPath), {
+                filename: path.basename(screenshotPath),
+                contentType: 'image/png',
+            })
+            await axios.post(
+                `https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendPhoto`,
+                form,
+                {
+                    timeout: 20000,
+                    httpsAgent,
+                    headers: form.getHeaders(),
+                    maxBodyLength: Infinity,
+                    maxContentLength: Infinity,
+                },
+            )
+            if (html.length > 1024) {
+                await axios.post(
+                    `https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage`,
+                    { chat_id: TELEGRAM_CHAT_ID, text: html.slice(1024, 1024 + 4096), parse_mode: 'HTML' },
+                    { timeout: 10000, httpsAgent },
+                )
+            }
+            return { ok: true, status: 200 }
+        }
+        const res = await axios.post(
+            `https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage`,
+            { chat_id: TELEGRAM_CHAT_ID, text: html.slice(0, 4096), parse_mode: 'HTML' },
+            { timeout: 10000, httpsAgent },
+        )
+        return { ok: true, status: res.status }
+    } catch (err) {
+        log.warn(`Telegram push failed: ${err.message}`)
+        return { ok: false, status: err.response?.status ?? 0, error: err.message }
+    }
+}
+
+// Fan-out to every configured chat channel. Runs Discord + Telegram in
+// parallel via allSettled so a Telegram outage can't drop a Discord push
+// (or vice versa). Kept named `discordPush` for now to avoid touching
+// every call site — the semantics are "push to all chat channels."
 async function discordPush(text, screenshotPath = null) {
+    const [discordRes] = await Promise.allSettled([
+        pushDiscordOnly(text, screenshotPath),
+        pushTelegram(text, screenshotPath),
+    ])
+    return discordRes.status === 'fulfilled' ? discordRes.value : { ok: false, status: 0 }
+}
+
+async function pushDiscordOnly(text, screenshotPath = null) {
     if (!DISCORD_WEBHOOK_URL) {
         log.warn('No CAMPSPOT_DISCORD_WEBHOOK_URL / WEBHOOK_URL in .env — skipping Discord push.')
         return { ok: false, status: 0 }

--- a/permit-bot/permit-bot.mjs
+++ b/permit-bot/permit-bot.mjs
@@ -37,12 +37,65 @@ const NTFY_TOPIC_URL = process.env.NTFY_TOPIC_URL || null
 // Bearer token. Public ntfy.sh topics ignore it — leaving unset keeps the
 // public-topic path working, so this is a strict superset of old behavior.
 const NTFY_AUTH_TOKEN = process.env.NTFY_AUTH_TOKEN || null
+// Telegram bot (opt-in via .env). Same channel as the campspot bot so the
+// user only has one Telegram to manage. Both required — either missing skips.
+const TELEGRAM_BOT_TOKEN = process.env.TELEGRAM_BOT_TOKEN || null
+const TELEGRAM_CHAT_ID = process.env.TELEGRAM_CHAT_ID || null
 // Permit-bot has its own Discord channel so cart-hold confirmations don't
 // drown out the campspot-checker's campground alerts. Falls back to the
 // campspot WEBHOOK_URL if no permit-specific one is set.
 const DISCORD_WEBHOOK_URL = process.env.PERMIT_DISCORD_WEBHOOK_URL
     || process.env.WEBHOOK_URL
     || null
+
+// Convert Discord-flavored **bold** to Telegram HTML <b>bold</b>. Escape
+// <, >, & first so user content can't inject markup.
+function telegramFormatText(text) {
+    const escaped = text
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+    return escaped.replace(/\*\*([^*\n]+)\*\*/g, '<b>$1</b>')
+}
+
+async function pushTelegram(text, screenshotPath = null) {
+    if (!TELEGRAM_BOT_TOKEN || !TELEGRAM_CHAT_ID) return { ok: false, status: 0, skipped: true }
+    try {
+        const html = telegramFormatText(text)
+        if (screenshotPath) {
+            const form = new FormData()
+            form.append('chat_id', TELEGRAM_CHAT_ID)
+            form.append('parse_mode', 'HTML')
+            form.append('caption', html.slice(0, 1024))
+            form.append('photo', createReadStream(screenshotPath), {
+                filename: path.basename(screenshotPath),
+                contentType: 'image/png',
+            })
+            await axios.post(
+                `https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendPhoto`,
+                form,
+                { timeout: 20000, httpsAgent, headers: form.getHeaders(), maxBodyLength: Infinity, maxContentLength: Infinity },
+            )
+            if (html.length > 1024) {
+                await axios.post(
+                    `https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage`,
+                    { chat_id: TELEGRAM_CHAT_ID, text: html.slice(1024, 1024 + 4096), parse_mode: 'HTML' },
+                    { timeout: 10000, httpsAgent },
+                )
+            }
+            return { ok: true, status: 200 }
+        }
+        const res = await axios.post(
+            `https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage`,
+            { chat_id: TELEGRAM_CHAT_ID, text: html.slice(0, 4096), parse_mode: 'HTML' },
+            { timeout: 10000, httpsAgent },
+        )
+        return { ok: true, status: res.status }
+    } catch (err) {
+        log.warn(`Telegram push failed: ${err.message}`)
+        return { ok: false, status: err.response?.status ?? 0, error: err.message }
+    }
+}
 
 // Discord delivery telemetry. Tracks consecutive failures + last error so the
 // heartbeat can surface "Discord is broken" without the user discovering it
@@ -60,6 +113,10 @@ const discordTelemetry = {
 // image is attached as a multipart upload so the user can verify visually
 // without leaving Discord.
 async function discordPush(text, screenshotPath = null) {
+    // Telegram side-channel — fire-and-forget so a Telegram outage can't
+    // affect Discord retries or the outbox flow. Skipped if either
+    // TELEGRAM_BOT_TOKEN or TELEGRAM_CHAT_ID is unset.
+    pushTelegram(text, screenshotPath).catch(() => {})
     if (!DISCORD_WEBHOOK_URL) {
         log.warn('No WEBHOOK_URL in .env — skipping Discord push.')
         return { ok: false, status: 0, error: 'no_webhook' }


### PR DESCRIPTION
## Summary
Adds Telegram push support to both `campspot-bot` and `permit-bot`. Every current `discordPush()` call site now also fans out to Telegram — same message, same optional screenshot — with **zero call-site changes**. Discord stays as the desktop channel, Telegram becomes the phone alert channel (a nice replacement for ntfy that ships `sendPhoto` natively so the cart screenshot lands in the chat).

## Config

Opt-in via `.env`:
- `TELEGRAM_BOT_TOKEN` — from @BotFather's `/newbot` flow
- `TELEGRAM_CHAT_ID` — from `https://api.telegram.org/bot<TOKEN>/getUpdates` after DMing the bot

Either unset → Telegram silently skipped. Existing `.env` files are unaffected (strict superset).

## Design

- **Formatting:** `**bold**` → `<b>bold</b>` via `parse_mode=HTML`. `<`, `>`, `&` in dynamic content escaped first so a stray user string can't inject markup. Discord's Markdown continues to work in Discord — Telegram transform happens inside `pushTelegram`, not at call sites.
- **Screenshots:** `sendPhoto` with caption for the first 1024 chars, spills overflow to a follow-up `sendMessage` (Telegram's caption limit).
- **Delivery model differs slightly by bot**:
  - `campspot-bot`: `Promise.allSettled([pushDiscordOnly, pushTelegram])` in parallel, wrapped by a refactored `discordPush` that keeps the old name so call sites don't change.
  - `permit-bot`: fire-and-forget `pushTelegram(...).catch(() => {})` at the top of `discordPush` — that path already has telemetry + outbox-retry complexity we don't want to entangle with Telegram delivery.

## Test plan
- [x] `npm test --testPathIgnorePatterns=availability-checker` — 214 passing
- [ ] After merge + deploy: set env on Mac + Alienware, restart bots, force a test push, verify the message + screenshot land in Telegram chat

🤖 Generated with [Claude Code](https://claude.com/claude-code)